### PR TITLE
feat: dim whitespace-only changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -533,6 +533,34 @@ the cost the limit is about. Both ends read `MAX_FILE_BYTES` and
 `FILE_TOO_LARGE` from `src/lib/diffHydration.ts`, so they cannot come to differ
 about the figure or the sentence.
 
+**A changed line that says less than its colour claims is dimmed, and never
+hidden.** `findLineMarks` in `src/lib/lineMarks.ts` reads each file's own change
+blocks and names the pairs whose two sides differ only in whitespace — the
+`git diff -w` rule — which are a formatting pass, so both sides go quiet. All of
+it is text arithmetic over the patch, ready at parse time, and honest about its
+limit: this is not SemanticDiff's syntax tree, and `0x80` against `128` still
+reads as a change. Dim and never hide, because a hidden line would break the
+promise this app is built on — a comment anchored to GitHub's own diff lines —
+where a dim one can still be read, selected and commented on.
+
+**The marks travel through the one per-line door the viewer has.**
+`@pierre/diffs` draws each file in a shadow root and has no line-decoration
+option, but `onPostRender` hands over the file's container after every render
+pass, and `unsafeCSS` installs a stylesheet inside the root. So `applyLineMarks`
+in `src/components/diffLineMarks.ts` stamps `data-ghdiff-quiet` onto the rows
+each pass just built — matched by the library's own `data-line` and
+`data-line-type`, in split and unified alike — and `LINE_MARKS_CSS` says what
+the stamp looks like. A pass renders only the virtualized window, so a walk
+touches tens of rows, and it re-runs because the next pass rebuilds them. The
+display-menu switch costs no render at all: the stamps stay, and
+`--ghdiff-quiet-opacity` — a custom property set beside the viewer and inherited
+through the shadow boundary — is the whole toggle, the same trick `usePaneWidth`
+plays. Marks are cached in a WeakMap per metadata object, which hydration
+mutates in place and a filter change reuses, so an entry cannot go stale.
+`fileDiffCache` is protected in the library's types and a plain getter at
+runtime; the cast in `ReviewViewer` is the one place that leans on it, and a
+library upgrade must re-check it.
+
 One thing GitHub decides rather than this app: a line comment written on an
 expanded line of a **pull request** is a line outside the diff, and the review
 comment API refuses one. The failure arrives as GitHub's own sentence in the

--- a/src/components/ReviewHeader.tsx
+++ b/src/components/ReviewHeader.tsx
@@ -289,6 +289,19 @@ export function ReviewHeader({
             >
               Change backgrounds
             </DropdownMenuCheckboxItem>
+            <DropdownMenuCheckboxItem
+              checked={controls.dimWhitespace}
+              indicator="switch"
+              onSelect={(event) => event.preventDefault()}
+              onCheckedChange={(checked) =>
+                onControlsChange({
+                  ...controls,
+                  dimWhitespace: checked === true,
+                })
+              }
+            >
+              Dim whitespace changes
+            </DropdownMenuCheckboxItem>
           </DropdownMenuContent>
         </DropdownMenu>
 

--- a/src/components/ReviewScreen.tsx
+++ b/src/components/ReviewScreen.tsx
@@ -506,6 +506,14 @@ export function ReviewScreen({ target }: { target: ReviewTarget }) {
             gridTemplateColumns: isPhone
               ? 'minmax(0,1fr)'
               : `var(${SIDEBAR_WIDTH_PROPERTY}) minmax(0,1fr)`,
+            // The whole effect of the dim switch. The marks are stamped on
+            // rows inside the viewer's shadow roots and styled by
+            // LINE_MARKS_CSS, whose default is the on state; this property
+            // inherits through the shadow boundary and overrides it, so a
+            // toggle is one style write and never a re-render of the diff.
+            ...(controls.dimWhitespace
+              ? undefined
+              : { '--ghdiff-quiet-opacity': '1' }),
           }}
         >
           <ReviewSidebar

--- a/src/components/ReviewViewer.tsx
+++ b/src/components/ReviewViewer.tsx
@@ -16,6 +16,7 @@ import { memo, type RefObject, useCallback, useMemo } from 'react';
 
 import { CommentComposer } from '@/components/CommentComposer';
 import { CommentThreadCard } from '@/components/CommentThreadCard';
+import { applyLineMarks, LINE_MARKS_CSS } from '@/components/diffLineMarks';
 import { Button } from '@/components/ui/Button';
 import { Tooltip } from '@/components/ui/Tooltip';
 import type { CommentStore } from '@/hooks/useReviewComments';
@@ -149,6 +150,18 @@ export const ReviewViewer = memo(function ReviewViewer({
       onGutterUtilityClick(range, context) {
         if (context.item.type !== 'diff') return;
         onCreateDraft(context.item.id, range);
+      },
+      // The stylesheet for the marks below, installed by the library inside
+      // each file's shadow root, where no outside selector can reach.
+      unsafeCSS: LINE_MARKS_CSS,
+      onPostRender(node, instance, phase) {
+        if (phase === 'unmount') return;
+        // `fileDiffCache` is protected in the type and a plain getter at
+        // runtime; there is no public path from an instance to its metadata.
+        const fileDiff = (
+          instance as unknown as { fileDiffCache?: FileDiffMetadata }
+        ).fileDiffCache;
+        applyLineMarks(node, fileDiff);
       },
     }),
     [

--- a/src/components/diffLineMarks.ts
+++ b/src/components/diffLineMarks.ts
@@ -1,0 +1,71 @@
+import type { FileDiffMetadata } from '@pierre/diffs';
+
+import { findLineMarks, type LineMarks } from '@/lib/lineMarks';
+
+// How the marks from src/lib/lineMarks.ts reach the rendered rows.
+//
+// The viewer draws each file in a shadow root and offers no per-line styling
+// option, but it does offer `onPostRender` — called with the file's container
+// after every render pass — and `unsafeCSS`, a stylesheet it installs inside
+// the shadow root. So the deal is: this module walks the rows the pass just
+// rendered and stamps `data-ghdiff-quiet` on the ones the marks name, and
+// LINE_MARKS_CSS says what the stamp looks like. A pass renders only the
+// virtualized window, so each walk touches tens of rows, and the whole thing
+// re-runs on the next pass because the rows are rebuilt.
+//
+// The dim is gated by a custom property rather than by re-render:
+// `--ghdiff-quiet-opacity` is set on the element around the viewer, inherits
+// through the shadow boundary, and flipping it is a style write that costs no
+// render — the same trick usePaneWidth plays.
+//
+// The rows are matched by the library's own `data-line` (the side's line
+// number) and `data-line-type`, which its selection and event code also read.
+
+/** Installed into every file's shadow root through the `unsafeCSS` option. */
+export const LINE_MARKS_CSS = `
+[data-ghdiff-quiet] {
+  opacity: var(--ghdiff-quiet-opacity, 0.5);
+}
+`;
+
+/**
+ * Marks are pure arithmetic over a file's own change blocks, so they are
+ * computed once per metadata object and remembered here. Hydration mutates
+ * that object in place without touching the change blocks, and a filter
+ * change keeps the same reference, so an entry never goes stale.
+ */
+const marksByFileDiff = new WeakMap<FileDiffMetadata, LineMarks | null>();
+
+function marksFor(fileDiff: FileDiffMetadata): LineMarks | null {
+  const cached = marksByFileDiff.get(fileDiff);
+  if (cached !== undefined) return cached;
+  const marks = findLineMarks(fileDiff) ?? null;
+  marksByFileDiff.set(fileDiff, marks);
+  return marks;
+}
+
+/**
+ * Stamps one file's rendered rows. Idempotent, and called from
+ * `onPostRender` on every mount and update pass.
+ */
+export function applyLineMarks(
+  container: HTMLElement,
+  fileDiff: FileDiffMetadata | undefined
+): void {
+  const root = container.shadowRoot;
+  if (root == null || fileDiff == null) return;
+
+  const marks = marksFor(fileDiff);
+  if (marks == null) return;
+  const rows = root.querySelectorAll<HTMLElement>(
+    '[data-line][data-line-type="change-deletion"], [data-line][data-line-type="change-addition"]'
+  );
+  for (const row of rows) {
+    const line = Number(row.getAttribute('data-line'));
+    const deletion = row.getAttribute('data-line-type') === 'change-deletion';
+    const quiet = deletion ? marks.quietDeletions : marks.quietAdditions;
+    if (quiet.has(line)) {
+      row.setAttribute('data-ghdiff-quiet', '');
+    }
+  }
+}

--- a/src/lib/lineMarks.test.ts
+++ b/src/lib/lineMarks.test.ts
@@ -1,0 +1,92 @@
+import { parsePatchFiles } from '@pierre/diffs';
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { findLineMarks } from './lineMarks.ts';
+
+// Every patch below is written the way git writes one, and parsed by the same
+// `parsePatchFiles` the app itself feeds, so the line numbers under test are
+// the numbers the gutter will show.
+
+function marksFrom(lines: string[]) {
+  const patch = [
+    'diff --git a/f.txt b/f.txt',
+    'index 1111111..2222222 100644',
+    '--- a/f.txt',
+    '+++ b/f.txt',
+    ...lines,
+    '',
+  ].join('\n');
+  const file = parsePatchFiles(patch, 'test')[0]?.files[0];
+  assert.ok(file != null, 'the patch parsed to a file diff');
+  return findLineMarks(file);
+}
+
+function sorted(set: Set<number> | undefined): number[] {
+  return [...(set ?? [])].sort((a, b) => a - b);
+}
+
+test('a re-indented block is quiet on both sides', () => {
+  const marks = marksFrom([
+    '@@ -1,4 +1,4 @@',
+    ' start',
+    '-value = 1',
+    '-print(value)',
+    '+    value = 1',
+    '+    print(value)',
+    ' end',
+  ]);
+  assert.ok(marks != null);
+  assert.deepEqual(sorted(marks.quietDeletions), [2, 3]);
+  assert.deepEqual(sorted(marks.quietAdditions), [2, 3]);
+});
+
+test('tabs against spaces and stripped trailing whitespace are quiet', () => {
+  const marks = marksFrom([
+    '@@ -1,3 +1,3 @@',
+    '-\tindented()',
+    '-trailing()   ',
+    '+        indented()',
+    '+trailing()',
+    ' end',
+  ]);
+  assert.ok(marks != null);
+  assert.deepEqual(sorted(marks.quietDeletions), [1, 2]);
+  assert.deepEqual(sorted(marks.quietAdditions), [1, 2]);
+});
+
+test('a changed line is not quiet', () => {
+  const marks = marksFrom([
+    '@@ -1,2 +1,2 @@',
+    '-total = a + b',
+    '+total = a - b',
+    ' end',
+  ]);
+  assert.equal(marks, undefined);
+});
+
+test('extra lines in an uneven block are never quiet', () => {
+  const marks = marksFrom([
+    '@@ -1,2 +1,3 @@',
+    '-  keep()',
+    '+keep()',
+    '+added()',
+    ' end',
+  ]);
+  assert.ok(marks != null);
+  assert.deepEqual(sorted(marks.quietDeletions), [1]);
+  assert.deepEqual(sorted(marks.quietAdditions), [1]);
+});
+
+test('whitespace inside a string is quiet by design', () => {
+  // `git diff -w` makes the same call. The dim keeps the line readable and
+  // the intraline highlight still lands on the exact characters.
+  const marks = marksFrom([
+    '@@ -1,2 +1,2 @@',
+    "-say('a b')",
+    "+say('ab')",
+    ' end',
+  ]);
+  assert.ok(marks != null);
+  assert.deepEqual(sorted(marks.quietAdditions), [1]);
+});

--- a/src/lib/lineMarks.ts
+++ b/src/lib/lineMarks.ts
@@ -1,0 +1,102 @@
+import type { ChangeContent, FileDiffMetadata, Hunk } from '@pierre/diffs';
+
+// Which changed lines say less than their colour claims.
+//
+// A diff paints every changed line red or green, and on a line whose two sides
+// differ only in whitespace the paint overstates: that is a formatting pass,
+// not a change a reviewer must judge. SemanticDiff hides such lines; ghdiff
+// dims them, which keeps every line on screen — a dim line can still be read,
+// selected and commented on, so a wrong call here costs emphasis and never
+// information.
+//
+// Everything here is computed from the patch alone — the hunks' own change
+// blocks and their lines — so it is ready the moment the diff is parsed and
+// never waits on a file fetch. That is also its honest limit: without a syntax
+// tree it cannot know that `0x80` is `128`, only that two lines are the same
+// text differently spaced.
+
+/** The subset of a file diff this module reads, so tests can hand it any
+    `parsePatchFiles` output directly. */
+export type LineMarksSource = Pick<
+  FileDiffMetadata,
+  'hunks' | 'deletionLines' | 'additionLines'
+>;
+
+export interface LineMarks {
+  /** Old-side line numbers whose pair differs only in whitespace. */
+  quietDeletions: Set<number>;
+  /** New-side line numbers whose pair differs only in whitespace. */
+  quietAdditions: Set<number>;
+}
+
+/**
+ * Marks for one file, or nothing when the file has none — which is most
+ * files, and what lets a caller keep no entry for them.
+ */
+export function findLineMarks(
+  fileDiff: LineMarksSource
+): LineMarks | undefined {
+  const marks: LineMarks = {
+    quietDeletions: new Set(),
+    quietAdditions: new Set(),
+  };
+
+  for (const hunk of fileDiff.hunks) {
+    for (const block of hunk.hunkContent) {
+      if (block.type !== 'change') continue;
+      collectQuietPairs(fileDiff, hunk, block, marks);
+    }
+  }
+
+  return marks.quietDeletions.size > 0 ? marks : undefined;
+}
+
+/** The line number a side's flat array index answers to, inside one hunk. */
+function lineNumberAt(
+  hunkStart: number,
+  hunkLineIndex: number,
+  arrayIndex: number
+): number {
+  return hunkStart + (arrayIndex - hunkLineIndex);
+}
+
+function stripAllWhitespace(text: string): string {
+  return text.replace(/\s+/g, '');
+}
+
+/**
+ * Pairs a block's deleted and added lines by position, the way intraline
+ * highlighting does, and records the pairs that differ only in whitespace.
+ * The rule is `git diff -w`: any change of spacing, indentation included.
+ * That deliberately covers whitespace inside a string literal, where spacing
+ * can matter — a dim keeps such a line readable, and the intraline highlight
+ * still lands on the exact characters.
+ */
+function collectQuietPairs(
+  fileDiff: LineMarksSource,
+  hunk: Hunk,
+  block: ChangeContent,
+  marks: LineMarks
+): void {
+  const pairs = Math.min(block.deletions, block.additions);
+  for (let offset = 0; offset < pairs; offset++) {
+    const deleted = fileDiff.deletionLines[block.deletionLineIndex + offset];
+    const added = fileDiff.additionLines[block.additionLineIndex + offset];
+    if (deleted == null || added == null) continue;
+    if (stripAllWhitespace(deleted) !== stripAllWhitespace(added)) continue;
+    marks.quietDeletions.add(
+      lineNumberAt(
+        hunk.deletionStart,
+        hunk.deletionLineIndex,
+        block.deletionLineIndex + offset
+      )
+    );
+    marks.quietAdditions.add(
+      lineNumberAt(
+        hunk.additionStart,
+        hunk.additionLineIndex,
+        block.additionLineIndex + offset
+      )
+    );
+  }
+}

--- a/src/lib/viewerControls.test.ts
+++ b/src/lib/viewerControls.test.ts
@@ -33,6 +33,7 @@ describe('acceptViewerControls', () => {
       overflow: 'wrap',
       lineNumbers: false,
       backgrounds: false,
+      dimWhitespace: false,
     };
     assert.deepEqual(acceptViewerControls(stored), stored);
   });
@@ -64,7 +65,7 @@ describe('acceptViewerControls', () => {
     assert.equal(acceptViewerControls(7), undefined);
   });
 
-  it('refuses an object that says nothing about any of the five', () => {
+  it('refuses an object that says nothing about any of the fields', () => {
     // A reviewer who has chosen nothing is not a reviewer who chose the
     // defaults: the screen still gets to pick, and a phone picks unified.
     assert.equal(acceptViewerControls({}), undefined);

--- a/src/lib/viewerControls.ts
+++ b/src/lib/viewerControls.ts
@@ -1,6 +1,6 @@
 import type { DiffIndicators } from '@pierre/diffs';
 
-// How the diff is drawn, which is the reviewer's own set of five answers.
+// How the diff is drawn, which is the reviewer's own set of answers.
 //
 // The viewer takes these one at a time. They are gathered into one object
 // because they are remembered as one: a reviewer who reads unified with no
@@ -18,6 +18,8 @@ export interface ViewerControls {
   overflow: 'wrap' | 'scroll';
   lineNumbers: boolean;
   backgrounds: boolean;
+  /** Dim a changed line whose two sides differ only in whitespace. */
+  dimWhitespace: boolean;
 }
 
 export const DEFAULT_VIEWER_CONTROLS: ViewerControls = {
@@ -26,6 +28,7 @@ export const DEFAULT_VIEWER_CONTROLS: ViewerControls = {
   overflow: 'scroll',
   lineNumbers: true,
   backgrounds: true,
+  dimWhitespace: true,
 };
 
 /** The same set with the one field a phone answers differently. */
@@ -56,12 +59,12 @@ function isDiffIndicators(value: unknown): value is DiffIndicators {
  *
  * Each field is taken on its own and falls back to the default on its own,
  * which is deliberate: this object gains fields as the header gains controls,
- * and a set stored by yesterday's build is still four right answers and one
+ * and a set stored by yesterday's build is still right answers plus one
  * absence. Refusing the whole object over the one missing field would throw
- * away the four.
+ * the rest away.
  *
- * `undefined` is the answer when the stored value says nothing about any of the
- * five — it is not an object, or it is an object with none of these fields in a
+ * `undefined` is the answer when the stored value says nothing about any of
+ * the fields — it is not an object, or it is an object with none of them in a
  * readable state. That is not the same answer as the default set: a reviewer
  * who has chosen nothing lets the screen pick, and a phone picks unified.
  */
@@ -101,6 +104,11 @@ export function acceptViewerControls(
       typeof stored.backgrounds === 'boolean',
       stored.backgrounds as boolean,
       DEFAULT_VIEWER_CONTROLS.backgrounds
+    ),
+    dimWhitespace: take(
+      typeof stored.dimWhitespace === 'boolean',
+      stored.dimWhitespace as boolean,
+      DEFAULT_VIEWER_CONTROLS.dimWhitespace
     ),
   };
   return read === 0 ? undefined : controls;


### PR DESCRIPTION
A changed line whose two sides differ only in whitespace — the git diff -w
rule — is a formatting pass, so both sides go quiet at half opacity instead
of full red and green. Nothing is hidden: a dim line can still be read,
selected and commented on. The display menu gains a switch, on by default,
whose whole effect is one custom property inherited into the viewer's
shadow roots.

Part of #4

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>