### PR TITLE
feat: moved-line marks, hunk scopes, and one-download hydration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ src/
     gh/$.tsx               the old /gh prefix, redirected to the route above
     api/diff.ts            one unified diff, as text/plain
     api/file.ts            one whole file, as text/plain
+    api/archive.ts         the new side of every changed file, as one tar.gz
     api/rpc/$.ts           the oRPC handler: every JSON call the app makes
   components/              the left bar, the review surface, and their chrome
   hooks/                   client state: patch, comments, pulls, the URL
@@ -463,18 +464,36 @@ also the one call whose HTTP status the client reads directly, for
 `describeReviewFailure`. `/api/file` is a route for the same reason and answers
 the same way; a source file is not much smaller than a patch.
 
-**The unmodified lines cost one request, and only for the new side.** A patch
-carries three lines of context around each change, and `@pierre/diffs` draws the
-rest of a file only once it has both whole sides — which is what `loadDiffFiles`
-hands it, and what puts the expand controls on a hunk separator in the first
-place. `/api/file` fetches the new side, and `src/lib/diffHydration.ts` rebuilds
-the old side from it: outside a hunk the two sides are the same lines by
-definition, and inside one the patch holds the old lines itself, so the old file
-is the new file with each hunk's new-side lines swapped back. That is a
-reverse-apply, it is exact, and it needs no merge base — which is the whole
-reason it is done this way. A pull request's diff runs from the merge base,
-`pull.base.sha` is not that commit, and asking GitHub for it costs a compare
-call whose answer carries up to 300 file patches with it.
+**The unmodified lines cost one request for the whole review, and only for the
+new side.** A patch carries three lines of context around each change, and
+`@pierre/diffs` draws the rest of a file only once it has both whole sides —
+which is what `loadDiffFiles` hands it, and what puts the expand controls on a
+hunk separator in the first place. The first expansion starts one `/api/archive`
+download, the tar.gz of the head commit's whole worktree, so a review is priced
+at one request rather than at its file count — three hundred changed files used
+to be three hundred requests against an anonymous quota of sixty an hour.
+`TarReader` in `src/lib/tar.ts` walks the stream as it arrives,
+`ArchiveFileCollector` keeps exactly the changed paths — deleted files excluded,
+because the head commit does not hold them and a path that can never be found
+would keep the download running to the end — and the download is cancelled the
+moment every wanted path is settled. The stream is counted before the gzip and
+abandoned past `MAX_ARCHIVE_DOWNLOAD_BYTES`, because an archive is priced by the
+repository rather than by the diff. Whatever it could not supply falls back to
+`/api/file`, one file at a time, and the archive's own failures are silent on
+purpose: the fallback is the path that already knows how to speak, and a
+reviewer should hear one explanation, not two. The display menu's **One download
+per review** switch is the reviewer's way out of the archive — off sends every
+press down the per-file path, which is what a metered connection wants from a
+repository whose archive outweighs the few files they will expand — and
+`ARCHIVE_HYDRATION_STORAGE_KEY` keeps the choice across sessions, on by default.
+Either way `src/lib/diffHydration.ts` rebuilds the old side from the new one:
+outside a hunk the two sides are the same lines by definition, and inside one
+the patch holds the old lines itself, so the old file is the new file with each
+hunk's new-side lines swapped back. That is a reverse-apply, it is exact, and it
+needs no merge base — which is the whole reason it is done this way. A pull
+request's diff runs from the merge base, `pull.base.sha` is not that commit, and
+asking GitHub for it costs a compare call whose answer carries up to 300 file
+patches with it.
 
 Exact only against the file the patch describes, though. A branch that moved
 between the diff and the press gives a new side the patch does not fit, and
@@ -485,19 +504,21 @@ out of the two arrays too. `patchFitsNewFile` is asked before every rebuild and
 foot of the screen says why. Never hydrate a side that has not been checked.
 
 **A file's commit is `refs/pull/{n}/head`, its own sha, or the range's head.**
-`newSideRef` in `src/routes/api/file.ts` answers for all three targets without a
-second request, and the pull ref resolves in the base repository even when the
-head belongs to a fork. A compare range typed across two forks addresses its
-head as `owner:branch`, which no source can read, so that one range gets no
-unmodified lines and says so.
+`newSideRef` in `src/lib/reviewTarget.ts` answers for all three targets without
+a second request, and `/api/archive` and `/api/file` both resolve through it, so
+the fallback fetches from the same commit the archive held. The pull ref
+resolves in the base repository even when the head belongs to a fork. A compare
+range typed across two forks addresses its head as `owner:branch`, which no
+source can read, so that one range gets no unmodified lines and says so.
 
 **Which source answers turns on the token, and only on the token.** A caller
 with none has sixty REST requests an hour and needs them for the comments and
-the pull request list, so its file comes from `raw.githubusercontent.com`, the
-host behind github.com's own **Raw** links, which spends none of them. A caller
-with a token has five thousand and may be reading a private repository, so its
-file comes from the contents API, which is the only one of the two that answers
-for one. One request per file either way, and the reviewer pays it once: the
+the pull request list, so its archive comes from `codeload.github.com` and its
+fallback file from `raw.githubusercontent.com` — the hosts behind github.com's
+own archive and **Raw** links — which spend none of them. A caller with a token
+has five thousand and may be reading a private repository, so its archive comes
+from the API's tarball endpoint and its file from the contents API, the pair
+that answers for one. However a file arrives, the reviewer pays for it once: the
 library hydrates the metadata object in place, and `items` keeps the same
 `fileDiff` reference through a filter change and a comment revision alike, so
 the lines stay expanded.
@@ -535,8 +556,13 @@ about the figure or the sentence.
 
 **A changed line that says less than its colour claims is dimmed, and never
 hidden.** `findLineMarks` in `src/lib/lineMarks.ts` reads each file's own change
-blocks and names the pairs whose two sides differ only in whitespace — the
-`git diff -w` rule — which are a formatting pass, so both sides go quiet. All of
+blocks and names two kinds of line. A pair whose two sides differ only in
+whitespace — the `git diff -w` rule — is a formatting pass, and both sides go
+quiet. A block of three or more lines that left one place and landed elsewhere
+in the same file, indentation aside and with at least twenty non-whitespace
+characters between its lines (git's own `--color-moved` floor), is a move, and
+both ends take the dim and an inset edge. Whitespace pairs are settled first and
+excluded from the move search, so a line never carries both explanations. All of
 it is text arithmetic over the patch, ready at parse time, and honest about its
 limit: this is not SemanticDiff's syntax tree, and `0x80` against `128` still
 reads as a change. Dim and never hide, because a hidden line would break the
@@ -547,19 +573,26 @@ where a dim one can still be read, selected and commented on.
 `@pierre/diffs` draws each file in a shadow root and has no line-decoration
 option, but `onPostRender` hands over the file's container after every render
 pass, and `unsafeCSS` installs a stylesheet inside the root. So `applyLineMarks`
-in `src/components/diffLineMarks.ts` stamps `data-ghdiff-quiet` onto the rows
-each pass just built — matched by the library's own `data-line` and
-`data-line-type`, in split and unified alike — and `LINE_MARKS_CSS` says what
-the stamp looks like. A pass renders only the virtualized window, so a walk
-touches tens of rows, and it re-runs because the next pass rebuilds them. The
-display-menu switch costs no render at all: the stamps stay, and
-`--ghdiff-quiet-opacity` — a custom property set beside the viewer and inherited
-through the shadow boundary — is the whole toggle, the same trick `usePaneWidth`
-plays. Marks are cached in a WeakMap per metadata object, which hydration
-mutates in place and a filter change reuses, so an entry cannot go stale.
-`fileDiffCache` is protected in the library's types and a plain getter at
-runtime; the cast in `ReviewViewer` is the one place that leans on it, and a
-library upgrade must re-check it.
+in `src/components/diffLineMarks.ts` stamps `data-ghdiff-quiet` and
+`data-ghdiff-moved` onto the rows each pass just built — matched by the
+library's own `data-line` and `data-line-type`, in split and unified alike — and
+`LINE_MARKS_CSS` says what a stamp looks like. A pass renders only the
+virtualized window, so a walk touches tens of rows, and it re-runs because the
+next pass rebuilds them. The two display-menu switches cost no render at all:
+the stamps stay, and `--ghdiff-quiet-opacity` with the moved pair — custom
+properties set beside the viewer and inherited through the shadow boundary — are
+the whole toggle, the same trick `usePaneWidth` plays. Marks are cached in a
+WeakMap per metadata object, which hydration mutates in place and a filter
+change reuses, so an entry cannot go stale. `fileDiffCache` is protected in the
+library's types and a plain getter at runtime; the cast in `ReviewViewer` is the
+one place that leans on it, and a library upgrade must re-check it.
+
+**The hunk separator names the scope, the way github.com's hunk headers do.**
+git writes the enclosing symbol after each hunk's `@@`, `parsePatchFiles` keeps
+it as `hunkContext`, and the renderer drops it. `applyScopeLabels` writes it
+back into the separator above hunk N, beside the unmodified-lines count, on the
+same pass as the marks. The trailing separator's index is one past the last hunk
+and so never names one.
 
 One thing GitHub decides rather than this app: a line comment written on an
 expanded line of a **pull request** is a line outside the diff, and the review

--- a/src/components/ReviewHeader.tsx
+++ b/src/components/ReviewHeader.tsx
@@ -69,6 +69,9 @@ const MARKERS: {
 ];
 
 interface ReviewHeaderProps {
+  /** True while expanded lines arrive as one archive download per review. */
+  archiveHydration: boolean;
+  onArchiveHydrationChange(next: boolean): void;
   codeFont: CodeFontState;
   colorMode: ColorModeState;
   controls: ViewerControls;
@@ -95,6 +98,8 @@ interface ReviewHeaderProps {
 }
 
 export function ReviewHeader({
+  archiveHydration,
+  onArchiveHydrationChange,
   codeFont,
   colorMode,
   controls,
@@ -301,6 +306,33 @@ export function ReviewHeader({
               }
             >
               Dim whitespace changes
+            </DropdownMenuCheckboxItem>
+            <DropdownMenuCheckboxItem
+              checked={controls.markMoves}
+              indicator="switch"
+              onSelect={(event) => event.preventDefault()}
+              onCheckedChange={(checked) =>
+                onControlsChange({ ...controls, markMoves: checked === true })
+              }
+            >
+              Mark moved lines
+            </DropdownMenuCheckboxItem>
+
+            <DropdownMenuSeparator />
+            {/* Behind its own rule because it is the one row here that changes
+                no pixel: on means expanded lines arrive as one archive download
+                for the whole review, off means one request per file, which is
+                what a metered connection wants from a repository whose archive
+                outweighs the few files a reviewer will actually expand. */}
+            <DropdownMenuCheckboxItem
+              checked={archiveHydration}
+              indicator="switch"
+              onSelect={(event) => event.preventDefault()}
+              onCheckedChange={(checked) =>
+                onArchiveHydrationChange(checked === true)
+              }
+            >
+              One download per review
             </DropdownMenuCheckboxItem>
           </DropdownMenuContent>
         </DropdownMenu>

--- a/src/components/ReviewScreen.tsx
+++ b/src/components/ReviewScreen.tsx
@@ -16,6 +16,7 @@ import { ReviewStatusPanel } from '@/components/ReviewStatusPanel';
 import { isSameSelection, ReviewViewer } from '@/components/ReviewViewer';
 import { Button } from '@/components/ui/Button';
 import {
+  archiveHydrationPreference,
   commentAuthorFilterPreference,
   usePreference,
   viewerControlsPreference,
@@ -118,6 +119,11 @@ export function ReviewScreen({ target }: { target: ReviewTarget }) {
   const { value: authorMode, setValue: setAuthorMode } = usePreference(
     commentAuthorFilterPreference
   );
+  // The switch in the display menu for how expanded lines travel: one archive
+  // download for the whole review, or one request per file. On by default; the
+  // codec refuses anything storage holds that is not a boolean.
+  const archivePref = usePreference(archiveHydrationPreference);
+  const archiveEnabled = archivePref.value;
 
   const patch = useReviewPatch({
     target,
@@ -139,9 +145,24 @@ export function ReviewScreen({ target }: { target: ReviewTarget }) {
     repo: pullTarget?.repo,
     token: token.token,
   });
+  // Every new-side path the archive should carry, unfiltered — a filter change
+  // must not decide what was downloaded. A deleted file's path is not in the
+  // head commit, and wanting it would keep the download running to the end.
+  const hydrationPaths = useMemo(
+    () =>
+      patch.data.items
+        .filter((item) => item.fileDiff.type !== 'deleted')
+        .map((item) => item.fileDiff.name),
+    [patch.data.items]
+  );
   // Only reached when a reviewer expands a hunk's unmodified lines, so it costs
   // nothing on a review nobody expands.
-  const files = useDiffFileLoader({ target, token: token.token });
+  const files = useDiffFileLoader({
+    target,
+    token: token.token,
+    paths: hydrationPaths,
+    archiveEnabled,
+  });
   const comments = useReviewComments({
     target,
     entries: patch.data.entries,
@@ -467,6 +488,8 @@ export function ReviewScreen({ target }: { target: ReviewTarget }) {
   return (
     <>
       <ReviewHeader
+        archiveHydration={archiveEnabled}
+        onArchiveHydrationChange={archivePref.setValue}
         codeFont={codeFont}
         colorMode={colorMode}
         controls={controls}
@@ -506,14 +529,21 @@ export function ReviewScreen({ target }: { target: ReviewTarget }) {
             gridTemplateColumns: isPhone
               ? 'minmax(0,1fr)'
               : `var(${SIDEBAR_WIDTH_PROPERTY}) minmax(0,1fr)`,
-            // The whole effect of the dim switch. The marks are stamped on
-            // rows inside the viewer's shadow roots and styled by
-            // LINE_MARKS_CSS, whose default is the on state; this property
-            // inherits through the shadow boundary and overrides it, so a
-            // toggle is one style write and never a re-render of the diff.
+            // The whole effect of the two mark switches. The marks are stamped
+            // on rows inside the viewer's shadow roots and styled by
+            // LINE_MARKS_CSS, whose defaults are the on state; these
+            // properties inherit through the shadow boundary and override
+            // them, so a toggle is one style write and never a re-render of
+            // the diff.
             ...(controls.dimWhitespace
               ? undefined
               : { '--ghdiff-quiet-opacity': '1' }),
+            ...(controls.markMoves
+              ? undefined
+              : {
+                  '--ghdiff-moved-opacity': '1',
+                  '--ghdiff-moved-edge': 'transparent',
+                }),
           }}
         >
           <ReviewSidebar

--- a/src/components/diffLineMarks.ts
+++ b/src/components/diffLineMarks.ts
@@ -8,23 +8,39 @@ import { findLineMarks, type LineMarks } from '@/lib/lineMarks';
 // option, but it does offer `onPostRender` — called with the file's container
 // after every render pass — and `unsafeCSS`, a stylesheet it installs inside
 // the shadow root. So the deal is: this module walks the rows the pass just
-// rendered and stamps `data-ghdiff-quiet` on the ones the marks name, and
-// LINE_MARKS_CSS says what the stamp looks like. A pass renders only the
-// virtualized window, so each walk touches tens of rows, and the whole thing
-// re-runs on the next pass because the rows are rebuilt.
+// rendered and stamps `data-ghdiff-quiet` and `data-ghdiff-moved` on the ones
+// the marks name, and LINE_MARKS_CSS says what those stamps look like. A pass
+// renders only the virtualized window, so each walk touches tens of rows, and
+// the whole thing re-runs on the next pass because the rows are rebuilt.
 //
-// The dim is gated by a custom property rather than by re-render:
-// `--ghdiff-quiet-opacity` is set on the element around the viewer, inherits
-// through the shadow boundary, and flipping it is a style write that costs no
-// render — the same trick usePaneWidth plays.
+// The dims are gated by custom properties rather than by re-render:
+// `--ghdiff-quiet-opacity` and the moved pair are set on the element around
+// the viewer, inherit through the shadow boundary, and flipping them is a
+// style write that costs no render — the same trick usePaneWidth plays.
 //
 // The rows are matched by the library's own `data-line` (the side's line
 // number) and `data-line-type`, which its selection and event code also read.
+// The hunk separator is matched by `data-separator` and `data-expand-index`,
+// hunk N's separator sitting above hunk N — which is where `hunkContext`, the
+// name after git's `@@`, belongs: it names the scope the hidden lines above
+// the hunk are inside.
 
 /** Installed into every file's shadow root through the `unsafeCSS` option. */
 export const LINE_MARKS_CSS = `
 [data-ghdiff-quiet] {
   opacity: var(--ghdiff-quiet-opacity, 0.5);
+}
+[data-ghdiff-moved] {
+  opacity: var(--ghdiff-moved-opacity, 0.62);
+  box-shadow: inset 2px 0 0 var(--ghdiff-moved-edge, color-mix(in srgb, currentColor 45%, transparent));
+}
+[data-ghdiff-scope] {
+  margin-left: 16px;
+  opacity: 0.65;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 `;
 
@@ -45,7 +61,7 @@ function marksFor(fileDiff: FileDiffMetadata): LineMarks | null {
 }
 
 /**
- * Stamps one file's rendered rows. Idempotent, and called from
+ * Stamps one file's rendered rows and separators. Idempotent, and called from
  * `onPostRender` on every mount and update pass.
  */
 export function applyLineMarks(
@@ -55,6 +71,8 @@ export function applyLineMarks(
   const root = container.shadowRoot;
   if (root == null || fileDiff == null) return;
 
+  applyScopeLabels(root, fileDiff);
+
   const marks = marksFor(fileDiff);
   if (marks == null) return;
   const rows = root.querySelectorAll<HTMLElement>(
@@ -63,9 +81,37 @@ export function applyLineMarks(
   for (const row of rows) {
     const line = Number(row.getAttribute('data-line'));
     const deletion = row.getAttribute('data-line-type') === 'change-deletion';
+    const moved = deletion ? marks.movedDeletions : marks.movedAdditions;
     const quiet = deletion ? marks.quietDeletions : marks.quietAdditions;
-    if (quiet.has(line)) {
+    if (moved.has(line)) {
+      row.setAttribute('data-ghdiff-moved', '');
+    } else if (quiet.has(line)) {
       row.setAttribute('data-ghdiff-quiet', '');
     }
+  }
+}
+
+/**
+ * Writes each hunk's `hunkContext` into the separator above it, beside the
+ * unmodified-lines count. The trailing separator's index is one past the last
+ * hunk and never names a scope, so it is skipped by the same lookup.
+ */
+function applyScopeLabels(root: ShadowRoot, fileDiff: FileDiffMetadata): void {
+  const separators = root.querySelectorAll<HTMLElement>(
+    '[data-separator="line-info"][data-expand-index]'
+  );
+  for (const separator of separators) {
+    const index = Number(separator.getAttribute('data-expand-index'));
+    const context = fileDiff.hunks[index]?.hunkContext?.trim();
+    if (context == null || context === '') continue;
+    const content = separator.querySelector('[data-separator-content]');
+    if (content == null) continue;
+    let label = content.querySelector('[data-ghdiff-scope]');
+    if (label == null) {
+      label = document.createElement('span');
+      label.setAttribute('data-ghdiff-scope', '');
+      content.appendChild(label);
+    }
+    if (label.textContent !== context) label.textContent = context;
   }
 }

--- a/src/hooks/preferences.ts
+++ b/src/hooks/preferences.ts
@@ -8,6 +8,7 @@ import {
   writeStoredString,
 } from './useLocalStorage';
 import {
+  ARCHIVE_HYDRATION_PREFERENCE,
   CODE_FONT_PREFERENCE,
   COLOR_MODE_PREFERENCE,
   COMMENT_AUTHOR_FILTER_PREFERENCE,
@@ -158,3 +159,6 @@ export const commentAuthorFilterPreference = preference(
 );
 export const sidebarWidthPreference = preference(SIDEBAR_WIDTH_PREFERENCE);
 export const railWidthPreference = preference(RAIL_WIDTH_PREFERENCE);
+export const archiveHydrationPreference = preference(
+  ARCHIVE_HYDRATION_PREFERENCE
+);

--- a/src/hooks/useDiffFileLoader.ts
+++ b/src/hooks/useDiffFileLoader.ts
@@ -1,7 +1,12 @@
 import type { FileDiffContentsLoader, FileDiffMetadata } from '@pierre/diffs';
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 import { withGitHubToken } from './useGitHubToken';
+import {
+  ArchiveFileCollector,
+  MAX_ARCHIVE_DOWNLOAD_BYTES,
+  MAX_ARCHIVE_KEPT_BYTES,
+} from '@/lib/archiveFiles';
 import {
   FILE_TOO_LARGE,
   MAX_FILE_BYTES,
@@ -11,14 +16,29 @@ import {
 } from '@/lib/diffHydration';
 import { type ReviewTarget, reviewTargetQuery } from '@/lib/reviewTarget';
 import { readStreamedText } from '@/lib/streamText';
+import { TarReader } from '@/lib/tar';
 
 // What the viewer calls when a reviewer expands the unmodified lines around a
 // hunk. `@pierre/diffs` asks for both whole files and keeps the patch's own
 // hunks, so the changes on screen do not move: what arrives fills in the lines
 // between them.
 //
-// One request per file, for the new side. The old side is rebuilt from it and
-// from the patch. See `src/lib/diffHydration.ts` for why that is exact.
+// The first expansion starts one `/api/archive` download for the whole review,
+// and every file after that is answered from what it kept — a review is priced
+// at one request, not at its file count. The download is walked as it arrives
+// and cancelled the moment every changed file is in hand. `/api/file` stays as
+// the per-file fallback, reached when the archive failed, ran past a cap, or
+// never held the path — a deleted file, a ref that moved. The archive's own
+// failures are silent on purpose: the fallback is the path that already knows
+// how to speak, and a reviewer should hear one explanation, not two.
+//
+// The switch in the header's display menu is `archiveEnabled`. Off means every
+// press pays for its own file, which is what a reviewer on a metered
+// connection wants from a repository whose archive outweighs the few files
+// they will actually expand.
+//
+// Either way the old side is rebuilt from the new one and the patch. See
+// `src/lib/diffHydration.ts` for why that is exact.
 
 // Both are said out loud rather than logged. A reviewer pressed something and
 // nothing happened, and the strip along the foot of the screen is where the
@@ -38,17 +58,46 @@ export interface DiffFileLoader {
 export function useDiffFileLoader(options: {
   target: ReviewTarget;
   token?: string;
+  /**
+   * Every changed file's new-side path, unfiltered — the archive is fetched
+   * once and has to carry the files the current filter hides. Deleted files
+   * are the caller's to leave out: their path is not in the head commit, and
+   * a path that can never be found would keep the download running to the end.
+   */
+  paths: readonly string[];
+  /** False sends every press down the per-file path and downloads no archive. */
+  archiveEnabled: boolean;
 }): DiffFileLoader {
-  const { target, token } = options;
+  const { archiveEnabled, target, token, paths } = options;
   const [error, setError] = useState<string | undefined>(undefined);
   // A string, not the target: the route's loader re-runs and hands down a new
   // object for the same review.
   const query = reviewTargetQuery(target).toString();
 
+  // One archive per review and token, started by the first expansion and
+  // shared by every one after it. A failure resolves to nothing rather than
+  // rejecting, so each file falls back on its own without a second download.
+  const archiveRef = useRef<
+    | { key: string; files: Promise<ArchiveFileCollector | undefined> }
+    | undefined
+  >(undefined);
+
   const loadDiffFiles = useCallback<FileDiffContentsLoader>(
     async (fileDiff: FileDiffMetadata) => {
+      const key = `${query}\u0000${token ?? ''}`;
+      if (archiveEnabled && archiveRef.current?.key !== key) {
+        archiveRef.current = {
+          key,
+          files: fetchArchiveFiles(query, token, paths).catch(() => undefined),
+        };
+      }
       try {
-        const contents = await fetchFile(query, fileDiff.name, token);
+        const contents = await fetchFileContents(
+          archiveEnabled ? archiveRef.current?.files : undefined,
+          query,
+          fileDiff.name,
+          token
+        );
         setError(undefined);
         const newFile = { name: fileDiff.name, contents };
         // A pure rename has no hunks and no old side to rebuild; the library
@@ -74,12 +123,97 @@ export function useDiffFileLoader(options: {
         throw cause;
       }
     },
-    [query, token]
+    [archiveEnabled, paths, query, token]
   );
 
   const dismissError = useCallback(() => setError(undefined), []);
 
   return { loadDiffFiles, error, dismissError };
+}
+
+async function fetchFileContents(
+  archive: Promise<ArchiveFileCollector | undefined> | undefined,
+  query: string,
+  path: string,
+  token: string | undefined
+): Promise<string> {
+  const collector = await archive;
+  if (collector != null) {
+    const found = collector.take(path);
+    if (found.kind === 'file') return found.text;
+    // Known too large from the tar header alone — the same answer a request
+    // would have bought, without the request.
+    if (found.kind === 'too-large') throw new Error(FILE_TOO_LARGE);
+  }
+  return fetchFile(query, path, token);
+}
+
+/**
+ * Downloads the review's archive and walks it as it arrives: counted before
+ * the gzip so the cap is about the bytes on the wire, decompressed by the
+ * browser's own stream, read entry by entry, and cancelled early when every
+ * wanted path has been settled.
+ */
+async function fetchArchiveFiles(
+  query: string,
+  token: string | undefined,
+  paths: readonly string[]
+): Promise<ArchiveFileCollector> {
+  const collector = new ArchiveFileCollector({
+    paths,
+    maxFileBytes: MAX_FILE_BYTES,
+    maxKeptBytes: MAX_ARCHIVE_KEPT_BYTES,
+  });
+  // A review of nothing but deletions wants no file at all.
+  if (collector.done) return collector;
+
+  const response = await fetch(`/api/archive?${query}`, withGitHubToken(token));
+  if (!response.ok) {
+    void response.body?.cancel();
+    throw new Error(`Archive request failed (${response.status}).`);
+  }
+  const body = response.body;
+  if (body == null) {
+    throw new Error('The archive response has no body to stream.');
+  }
+
+  let downloaded = 0;
+  const counted = body.pipeThrough(
+    new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        downloaded += chunk.byteLength;
+        if (downloaded > MAX_ARCHIVE_DOWNLOAD_BYTES) {
+          throw new Error('That archive is too large to read.');
+        }
+        controller.enqueue(chunk);
+      },
+    })
+  );
+  // The lib types DecompressionStream's writable as taking any BufferSource,
+  // which pipeThrough's invariant generics refuse; the stream itself both
+  // accepts and yields Uint8Array.
+  const gunzip = new DecompressionStream('gzip') as unknown as TransformStream<
+    Uint8Array,
+    Uint8Array
+  >;
+  const reader = counted.pipeThrough(gunzip).getReader();
+  const tar = new TarReader(collector);
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) {
+        tar.end();
+        break;
+      }
+      tar.push(value);
+      if (collector.done) break;
+    }
+  } finally {
+    // Releases the lock on the way out, and cancels the rest of the download
+    // when the loop broke early rather than the body having ended.
+    await reader.cancel().catch(() => undefined);
+  }
+  return collector;
 }
 
 async function fetchFile(

--- a/src/lib/archiveFiles.test.ts
+++ b/src/lib/archiveFiles.test.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { ArchiveFileCollector } from './archiveFiles.ts';
+
+const encoder = new TextEncoder();
+
+function collector(
+  paths: string[],
+  options: { maxFileBytes?: number; maxKeptBytes?: number } = {}
+): ArchiveFileCollector {
+  return new ArchiveFileCollector({
+    paths,
+    maxFileBytes: options.maxFileBytes ?? 1024,
+    maxKeptBytes: options.maxKeptBytes ?? 4096,
+  });
+}
+
+function offer(sink: ArchiveFileCollector, path: string, text: string): void {
+  const bytes = encoder.encode(text);
+  if (sink.wants({ path, size: bytes.byteLength })) {
+    sink.onFile(path, bytes);
+  }
+}
+
+test('a wanted path is matched under the archive root and taken once', () => {
+  const sink = collector(['src/a.ts']);
+  offer(sink, 'ghdiff-abc123/src/a.ts', 'const a = 1;\n');
+  assert.equal(sink.done, true);
+  assert.deepEqual(sink.take('src/a.ts'), {
+    kind: 'file',
+    text: 'const a = 1;\n',
+  });
+  assert.deepEqual(sink.take('src/a.ts'), { kind: 'missing' });
+});
+
+test('the rest of the repository is refused', () => {
+  const sink = collector(['src/a.ts']);
+  assert.equal(sink.wants({ path: 'root/README.md', size: 10 }), false);
+  assert.equal(sink.wants({ path: 'root-only-no-slash', size: 10 }), false);
+  assert.equal(sink.done, false);
+});
+
+test('a file past the per-file ceiling is remembered as too large', () => {
+  const sink = collector(['big.bin'], { maxFileBytes: 8 });
+  assert.equal(sink.wants({ path: 'root/big.bin', size: 9 }), false);
+  assert.equal(sink.done, true);
+  assert.deepEqual(sink.take('big.bin'), { kind: 'too-large' });
+});
+
+test('a file past the kept total is dropped, not remembered', () => {
+  const sink = collector(['a.txt', 'b.txt'], { maxKeptBytes: 10 });
+  offer(sink, 'root/a.txt', 'eight ch');
+  assert.equal(sink.wants({ path: 'root/b.txt', size: 8 }), false);
+  assert.equal(sink.done, true);
+  assert.deepEqual(sink.take('b.txt'), { kind: 'missing' });
+  assert.equal((sink.take('a.txt') as { text: string }).text, 'eight ch');
+});
+
+test('done waits for every wanted path', () => {
+  const sink = collector(['a.txt', 'b.txt']);
+  offer(sink, 'root/a.txt', 'first');
+  assert.equal(sink.done, false);
+  offer(sink, 'root/b.txt', 'second');
+  assert.equal(sink.done, true);
+});
+
+test('no wanted paths means done before the first byte', () => {
+  assert.equal(collector([]).done, true);
+});
+
+test('bytes decode as UTF-8', () => {
+  const sink = collector(['lä协.txt']);
+  offer(sink, 'root/lä协.txt', 'naïve — 协议\n');
+  assert.deepEqual(sink.take('lä协.txt'), {
+    kind: 'file',
+    text: 'naïve — 协议\n',
+  });
+});

--- a/src/lib/archiveFiles.ts
+++ b/src/lib/archiveFiles.ts
@@ -1,0 +1,108 @@
+// What the review keeps out of an archive, and what it refuses.
+//
+// One tar.gz of the head commit's worktree carries the new side of every
+// changed file, and this collector is the sink that walks it: it keeps the
+// paths the diff names, skips the rest of the repository unread, and answers
+// the loader afterwards, one file at a time. The paths in an archive open with
+// the root directory GitHub names after the repository and the ref, so every
+// comparison here happens on the path with that first segment cut off.
+//
+// Three refusals, each deliberate. A wanted file larger than the per-file
+// ceiling is remembered as too large, so the loader can say so without
+// spending a request to find out. A file that would take the kept total past
+// its ceiling is dropped and left for the per-file fallback, which only pays
+// for it if the reviewer actually expands it. And a path the archive never
+// held — a deleted file, a ref that moved — is simply missing, which sends the
+// loader down the same fallback.
+
+import type { TarEntryHeader, TarSink } from './tar.ts';
+
+/**
+ * Stop the download past this many compressed bytes. The figure is about the
+ * repository, not the diff: ghostty's whole worktree travels as 39 MB, and a
+ * repository whose archive runs past this is one whose changed files are
+ * cheaper to fetch one by one.
+ */
+export const MAX_ARCHIVE_DOWNLOAD_BYTES = 256 * 1024 * 1024;
+
+/**
+ * Stop keeping files past this many decoded bytes. Each kept file is already
+ * capped at MAX_FILE_BYTES; this is the guard for a review with thousands of
+ * them. What is dropped falls back to a per-file request, paid only when the
+ * reviewer expands that file.
+ */
+export const MAX_ARCHIVE_KEPT_BYTES = 128 * 1024 * 1024;
+
+export type ArchiveFileResult =
+  | { kind: 'file'; text: string }
+  | { kind: 'too-large' }
+  | { kind: 'missing' };
+
+export class ArchiveFileCollector implements TarSink {
+  /** The paths still being looked for. Empty is what ends the download. */
+  private readonly wanted: Set<string>;
+  private readonly files = new Map<string, string>();
+  private readonly tooLargePaths = new Set<string>();
+  private readonly maxFileBytes: number;
+  private readonly maxKeptBytes: number;
+  private keptBytes = 0;
+
+  constructor(options: {
+    /** Repo-relative paths, without the archive's root directory. */
+    paths: Iterable<string>;
+    maxFileBytes: number;
+    maxKeptBytes: number;
+  }) {
+    this.wanted = new Set(options.paths);
+    this.maxFileBytes = options.maxFileBytes;
+    this.maxKeptBytes = options.maxKeptBytes;
+  }
+
+  wants(header: TarEntryHeader): boolean {
+    const path = innerPath(header.path);
+    if (path == null || !this.wanted.has(path)) return false;
+    if (header.size > this.maxFileBytes) {
+      this.wanted.delete(path);
+      this.tooLargePaths.add(path);
+      return false;
+    }
+    if (this.keptBytes + header.size > this.maxKeptBytes) {
+      this.wanted.delete(path);
+      return false;
+    }
+    return true;
+  }
+
+  onFile(path: string, bytes: Uint8Array): void {
+    const inner = innerPath(path);
+    if (inner == null || !this.wanted.delete(inner)) return;
+    this.keptBytes += bytes.byteLength;
+    this.files.set(inner, new TextDecoder().decode(bytes));
+  }
+
+  /** True once every wanted path is settled. The download can stop here. */
+  get done(): boolean {
+    return this.wanted.size === 0;
+  }
+
+  /**
+   * The file's text, handed over once: the library hydrates a file a single
+   * time, so a copy kept after this call would only be memory.
+   */
+  take(path: string): ArchiveFileResult {
+    const text = this.files.get(path);
+    if (text != null) {
+      this.files.delete(path);
+      return { kind: 'file', text };
+    }
+    if (this.tooLargePaths.has(path)) return { kind: 'too-large' };
+    return { kind: 'missing' };
+  }
+}
+
+/** The path without the archive's root directory, or nothing for the root. */
+function innerPath(path: string): string | undefined {
+  const slash = path.indexOf('/');
+  if (slash < 0 || slash === path.length - 1) return undefined;
+  return path.slice(slash + 1);
+}

--- a/src/lib/lineMarks.test.ts
+++ b/src/lib/lineMarks.test.ts
@@ -39,6 +39,7 @@ test('a re-indented block is quiet on both sides', () => {
   assert.ok(marks != null);
   assert.deepEqual(sorted(marks.quietDeletions), [2, 3]);
   assert.deepEqual(sorted(marks.quietAdditions), [2, 3]);
+  assert.equal(marks.movedDeletions.size, 0);
 });
 
 test('tabs against spaces and stripped trailing whitespace are quiet', () => {
@@ -89,4 +90,120 @@ test('whitespace inside a string is quiet by design', () => {
   ]);
   assert.ok(marks != null);
   assert.deepEqual(sorted(marks.quietAdditions), [1]);
+});
+
+test('a block that reappears further down is a move on both sides', () => {
+  const marks = marksFrom([
+    '@@ -1,5 +1,1 @@',
+    '-def helper(x):',
+    '-    y = x * 2',
+    '-    return y + 1',
+    '-',
+    ' top',
+    '@@ -20,2 +16,6 @@',
+    ' middle',
+    '+def helper(x):',
+    '+    y = x * 2',
+    '+    return y + 1',
+    '+',
+    ' bottom',
+  ]);
+  assert.ok(marks != null);
+  // The trailing blank line travelled with the block, so it is part of it.
+  assert.deepEqual(sorted(marks.movedDeletions), [1, 2, 3, 4]);
+  assert.deepEqual(sorted(marks.movedAdditions), [17, 18, 19, 20]);
+  assert.equal(marks.quietDeletions.size, 0);
+});
+
+test('a moved block keeps matching after a re-indent', () => {
+  const marks = marksFrom([
+    '@@ -1,4 +1,1 @@',
+    '-alpha(1)',
+    '-beta(22)',
+    '-gamma(333)',
+    ' top',
+    '@@ -20,2 +17,5 @@',
+    ' middle',
+    '+    alpha(1)',
+    '+    beta(22)',
+    '+    gamma(333)',
+    ' bottom',
+  ]);
+  assert.ok(marks != null);
+  assert.deepEqual(sorted(marks.movedDeletions), [1, 2, 3]);
+  assert.deepEqual(sorted(marks.movedAdditions), [18, 19, 20]);
+});
+
+test('two matching lines are not a move', () => {
+  const marks = marksFrom([
+    '@@ -1,3 +1,1 @@',
+    '-alpha(111)',
+    '-beta(2222)',
+    ' top',
+    '@@ -20,2 +18,4 @@',
+    ' middle',
+    '+alpha(111)',
+    '+beta(2222)',
+    ' bottom',
+  ]);
+  assert.equal(marks, undefined);
+});
+
+test('three near-empty lines are not a move', () => {
+  const marks = marksFrom([
+    '@@ -1,4 +1,1 @@',
+    '-}',
+    '-)',
+    '-]',
+    ' top',
+    '@@ -20,2 +17,5 @@',
+    ' middle',
+    '+}',
+    '+)',
+    '+]',
+    ' bottom',
+  ]);
+  assert.equal(marks, undefined);
+});
+
+test('a block must be contiguous on both sides to move', () => {
+  // The same three lines reappear, but split across two places: the gap on
+  // the addition side breaks the block, and no single run reaches three
+  // lines.
+  const marks = marksFrom([
+    '@@ -1,4 +1,1 @@',
+    '-alpha(1)',
+    '-beta(22)',
+    '-gamma(333)',
+    ' top',
+    '@@ -20,3 +17,6 @@',
+    ' middle',
+    '+alpha(1)',
+    '+beta(22)',
+    ' gap',
+    '+gamma(333)',
+    ' bottom',
+  ]);
+  assert.equal(marks, undefined);
+});
+
+test('a quiet pair is never also a move', () => {
+  // Line 1 pairs with its own re-indent, so the identical block added at the
+  // foot must not claim it.
+  const marks = marksFrom([
+    '@@ -1,3 +1,3 @@',
+    '-first_line(1)',
+    '+    first_line(1)',
+    ' top',
+    '@@ -20,2 +20,5 @@',
+    ' middle',
+    '+first_line(1)',
+    '+second_line(22)',
+    '+third_line(333)',
+    ' bottom',
+  ]);
+  assert.ok(marks != null);
+  assert.deepEqual(sorted(marks.quietDeletions), [1]);
+  assert.equal(marks.movedDeletions.size, 0);
+  assert.equal(marks.movedAdditions.size, 0);
 });

--- a/src/lib/lineMarks.ts
+++ b/src/lib/lineMarks.ts
@@ -2,18 +2,42 @@ import type { ChangeContent, FileDiffMetadata, Hunk } from '@pierre/diffs';
 
 // Which changed lines say less than their colour claims.
 //
-// A diff paints every changed line red or green, and on a line whose two sides
-// differ only in whitespace the paint overstates: that is a formatting pass,
-// not a change a reviewer must judge. SemanticDiff hides such lines; ghdiff
-// dims them, which keeps every line on screen — a dim line can still be read,
-// selected and commented on, so a wrong call here costs emphasis and never
-// information.
+// A diff paints every changed line red or green, and on two kinds of line the
+// paint overstates. A line whose two sides differ only in whitespace is a
+// formatting pass, not a change a reviewer must judge. And a line that left
+// one place and landed unaltered in another is code the reviewer has already
+// read once. SemanticDiff hides the first kind and draws the second as a move;
+// ghdiff dims the first and edges the second, which keeps every line on
+// screen — a dim line can still be read, selected and commented on, so a wrong
+// call here costs emphasis and never information.
 //
 // Everything here is computed from the patch alone — the hunks' own change
 // blocks and their lines — so it is ready the moment the diff is parsed and
 // never waits on a file fetch. That is also its honest limit: without a syntax
 // tree it cannot know that `0x80` is `128`, only that two lines are the same
-// text differently spaced.
+// text differently spaced, or the same text somewhere else.
+
+/**
+ * A moved block must be at least this many lines. One or two matching lines
+ * are how ordinary edits look — a closing brace, a blank line, an import —
+ * and marking those as moves would mark most diffs.
+ */
+const MIN_MOVED_BLOCK_LINES = 3;
+
+/**
+ * And its lines must carry at least this many non-whitespace characters
+ * between them, which is git's own floor for `--color-moved`: three brace
+ * lines are three matching lines and still say nothing.
+ */
+const MIN_MOVED_BLOCK_CHARS = 20;
+
+/**
+ * A line whose text appears in the additions more often than this never
+ * anchors a move: it is punctuation of the language, not an address, and
+ * chasing every occurrence would make the search quadratic on brace-heavy
+ * files.
+ */
+const MAX_ANCHOR_OCCURRENCES = 10;
 
 /** The subset of a file diff this module reads, so tests can hand it any
     `parsePatchFiles` output directly. */
@@ -27,6 +51,20 @@ export interface LineMarks {
   quietDeletions: Set<number>;
   /** New-side line numbers whose pair differs only in whitespace. */
   quietAdditions: Set<number>;
+  /** Old-side line numbers of blocks that reappear unaltered elsewhere. */
+  movedDeletions: Set<number>;
+  /** New-side line numbers those blocks reappear on. */
+  movedAdditions: Set<number>;
+}
+
+/** One changed line of a block, addressed by the number the gutter shows. */
+interface ChangedLine {
+  line: number;
+  /** The text without its line break or surrounding whitespace, so a block
+      keeps matching after a re-indent. */
+  norm: string;
+  /** The text without any whitespace at all, for the two equality tests. */
+  bare: string;
 }
 
 /**
@@ -39,16 +77,48 @@ export function findLineMarks(
   const marks: LineMarks = {
     quietDeletions: new Set(),
     quietAdditions: new Set(),
+    movedDeletions: new Set(),
+    movedAdditions: new Set(),
   };
+
+  const deletions: ChangedLine[] = [];
+  const additions: ChangedLine[] = [];
 
   for (const hunk of fileDiff.hunks) {
     for (const block of hunk.hunkContent) {
       if (block.type !== 'change') continue;
       collectQuietPairs(fileDiff, hunk, block, marks);
+      // What the whitespace pass claimed is already explained, so the move
+      // search never sees it: a line equal to its own pair cannot also have
+      // "come from" somewhere else.
+      collectChangedLines(
+        fileDiff.deletionLines,
+        hunk.deletionStart,
+        hunk.deletionLineIndex,
+        block.deletionLineIndex,
+        block.deletions,
+        marks.quietDeletions,
+        deletions
+      );
+      collectChangedLines(
+        fileDiff.additionLines,
+        hunk.additionStart,
+        hunk.additionLineIndex,
+        block.additionLineIndex,
+        block.additions,
+        marks.quietAdditions,
+        additions
+      );
     }
   }
 
-  return marks.quietDeletions.size > 0 ? marks : undefined;
+  findMovedBlocks(deletions, additions, marks);
+
+  return marks.quietDeletions.size > 0 ||
+    marks.quietAdditions.size > 0 ||
+    marks.movedDeletions.size > 0
+    ? marks
+    : undefined;
 }
 
 /** The line number a side's flat array index answers to, inside one hunk. */
@@ -99,4 +169,150 @@ function collectQuietPairs(
       )
     );
   }
+}
+
+function collectChangedLines(
+  sideLines: readonly string[],
+  hunkStart: number,
+  hunkLineIndex: number,
+  blockLineIndex: number,
+  blockCount: number,
+  quiet: ReadonlySet<number>,
+  into: ChangedLine[]
+): void {
+  for (let offset = 0; offset < blockCount; offset++) {
+    const text = sideLines[blockLineIndex + offset];
+    if (text == null) continue;
+    const line = lineNumberAt(
+      hunkStart,
+      hunkLineIndex,
+      blockLineIndex + offset
+    );
+    if (quiet.has(line)) continue;
+    const norm = text.replace(/\r?\n$/, '').trim();
+    into.push({ line, norm, bare: stripAllWhitespace(norm) });
+  }
+}
+
+/**
+ * Finds deleted blocks that reappear as added blocks, by exact text with
+ * indentation allowed to differ. Anchors are uncommon lines; a match extends
+ * up and down while both sides stay equal, unclaimed, and contiguous in
+ * their own file. Contiguity is what keeps a block a block: the flat arrays
+ * run across hunks, and a match must not.
+ */
+function findMovedBlocks(
+  deletions: readonly ChangedLine[],
+  additions: readonly ChangedLine[],
+  marks: LineMarks
+): void {
+  if (deletions.length < MIN_MOVED_BLOCK_LINES) return;
+  const byNorm = new Map<string, number[]>();
+  additions.forEach((added, index) => {
+    if (added.bare === '') return;
+    const list = byNorm.get(added.norm);
+    if (list == null) byNorm.set(added.norm, [index]);
+    else list.push(index);
+  });
+
+  const matchedDeletions = new Array<boolean>(deletions.length).fill(false);
+  const matchedAdditions = new Array<boolean>(additions.length).fill(false);
+
+  for (let anchor = 0; anchor < deletions.length; anchor++) {
+    if (matchedDeletions[anchor]) continue;
+    const entry = deletions[anchor];
+    if (entry == null || entry.bare === '') continue;
+    const candidates = byNorm.get(entry.norm);
+    if (candidates == null || candidates.length > MAX_ANCHOR_OCCURRENCES) {
+      continue;
+    }
+
+    let best: { start: number; addedStart: number; length: number } | null =
+      null;
+    for (const candidate of candidates) {
+      if (matchedAdditions[candidate]) continue;
+      const match = extendMatch(
+        deletions,
+        additions,
+        matchedDeletions,
+        matchedAdditions,
+        anchor,
+        candidate
+      );
+      if (best == null || match.length > best.length) best = match;
+    }
+    if (best == null || best.length < MIN_MOVED_BLOCK_LINES) continue;
+
+    let significantChars = 0;
+    for (let offset = 0; offset < best.length; offset++) {
+      significantChars += deletions[best.start + offset]?.bare.length ?? 0;
+    }
+    if (significantChars < MIN_MOVED_BLOCK_CHARS) continue;
+
+    for (let offset = 0; offset < best.length; offset++) {
+      const deleted = deletions[best.start + offset];
+      const added = additions[best.addedStart + offset];
+      if (deleted == null || added == null) continue;
+      matchedDeletions[best.start + offset] = true;
+      matchedAdditions[best.addedStart + offset] = true;
+      marks.movedDeletions.add(deleted.line);
+      marks.movedAdditions.add(added.line);
+    }
+  }
+}
+
+/** How far a match at (anchor, candidate) reaches in both directions. */
+function extendMatch(
+  deletions: readonly ChangedLine[],
+  additions: readonly ChangedLine[],
+  matchedDeletions: readonly boolean[],
+  matchedAdditions: readonly boolean[],
+  anchor: number,
+  candidate: number
+): { start: number; addedStart: number; length: number } {
+  const stillEqual = (
+    deletionIndex: number,
+    additionIndex: number
+  ): boolean => {
+    const deleted = deletions[deletionIndex];
+    const added = additions[additionIndex];
+    return (
+      deleted != null &&
+      added != null &&
+      !matchedDeletions[deletionIndex] &&
+      !matchedAdditions[additionIndex] &&
+      deleted.norm === added.norm
+    );
+  };
+  const contiguous = (
+    lines: readonly ChangedLine[],
+    from: number,
+    to: number
+  ): boolean => {
+    const a = lines[from];
+    const b = lines[to];
+    return a != null && b != null && Math.abs(b.line - a.line) === 1;
+  };
+
+  let up = 0;
+  while (
+    stillEqual(anchor - up - 1, candidate - up - 1) &&
+    contiguous(deletions, anchor - up, anchor - up - 1) &&
+    contiguous(additions, candidate - up, candidate - up - 1)
+  ) {
+    up += 1;
+  }
+  let down = 0;
+  while (
+    stillEqual(anchor + down + 1, candidate + down + 1) &&
+    contiguous(deletions, anchor + down, anchor + down + 1) &&
+    contiguous(additions, candidate + down, candidate + down + 1)
+  ) {
+    down += 1;
+  }
+  return {
+    start: anchor - up,
+    addedStart: candidate - up,
+    length: up + down + 1,
+  };
 }

--- a/src/lib/preferences.test.ts
+++ b/src/lib/preferences.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
 import {
+  ARCHIVE_HYDRATION_PREFERENCE,
   CODE_FONT_PREFERENCE,
   COLOR_MODE_PREFERENCE,
   COMMENT_AUTHOR_FILTER_PREFERENCE,
@@ -19,6 +20,7 @@ import { DEFAULT_VIEWER_CONTROLS } from './viewerControls.ts';
 // nine separately. The two directions are methods, which TypeScript treats as
 // bivariant, so one `unknown` codec stands for all of them.
 const ALL: PreferenceCodec<unknown>[] = [
+  ARCHIVE_HYDRATION_PREFERENCE,
   CODE_FONT_PREFERENCE,
   COLOR_MODE_PREFERENCE,
   COMMENT_AUTHOR_FILTER_PREFERENCE,

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -6,6 +6,7 @@ import {
 } from './commentAuthors.ts';
 import { dedupeWatchedRepos, type WatchedRepo } from './pulls.ts';
 import {
+  ARCHIVE_HYDRATION_STORAGE_KEY,
   CODE_FONT_STORAGE_KEY,
   COLOR_MODE_STORAGE_KEY,
   COMMENT_AUTHOR_FILTER_STORAGE_KEY,
@@ -170,6 +171,18 @@ export const VIEWER_CONTROLS_PREFERENCE = jsonPreference<ViewerControls | null>(
 export const RAIL_COLLAPSED_PREFERENCE = jsonPreference<boolean>(
   RAIL_COLLAPSED_STORAGE_KEY,
   false,
+  (value) => (typeof value === 'boolean' ? value : undefined)
+);
+
+/**
+ * Whether the unmodified lines arrive as one archive download per review, or
+ * one request per file. On by default, and off is what a metered connection
+ * wants from a repository whose archive outweighs the few files a reviewer
+ * will expand.
+ */
+export const ARCHIVE_HYDRATION_PREFERENCE = jsonPreference<boolean>(
+  ARCHIVE_HYDRATION_STORAGE_KEY,
+  true,
   (value) => (typeof value === 'boolean' ? value : undefined)
 );
 

--- a/src/lib/reviewTarget.ts
+++ b/src/lib/reviewTarget.ts
@@ -45,6 +45,32 @@ export function supportsGitHubComments(
   return target.kind === 'github-pull';
 }
 
+/**
+ * The commit whose copy of a file the patch's new side describes. Both
+ * `/api/file` and `/api/archive` resolve their ref through this one function,
+ * so the file a fallback fetches is the file the archive would have held.
+ *
+ * A pull request answers through `refs/pull/{n}/head`, which GitHub keeps in
+ * the base repository and which needs no second request to resolve — and works
+ * for a pull request from a fork, where the head commit lives nowhere else
+ * those routes can reach.
+ *
+ * A compare range answers with whatever it was addressed by. That is a branch
+ * or a sha of this repository for every range ghdiff has a link to, and it is
+ * `owner:branch` for a range typed across two forks — which no source can
+ * read, so such a range gets no unmodified lines and says so.
+ */
+export function newSideRef(target: ReviewTarget): string {
+  switch (target.kind) {
+    case 'github-pull':
+      return `refs/pull/${target.number}/head`;
+    case 'github-commit':
+      return target.sha;
+    case 'github-compare':
+      return target.head;
+  }
+}
+
 /** Stable key for caches and for browser-side comment storage. */
 export function reviewTargetKey(target: ReviewTarget): string {
   switch (target.kind) {

--- a/src/lib/server/github.ts
+++ b/src/lib/server/github.ts
@@ -312,6 +312,56 @@ export async function githubWebDiff(
   return response;
 }
 
+// --- Where a whole worktree's archive comes from ------------------------------
+
+const GITHUB_CODELOAD_HOST = 'https://codeload.github.com';
+
+/**
+ * Fetches the tar.gz of one ref's whole worktree — the transport behind the
+ * expand controls, which carries the new side of every changed file in one
+ * request instead of one request each.
+ *
+ * The source turns on the token, the same split as a single file. A caller
+ * with none is served by codeload, the host behind github.com's own archive
+ * links: it answers for a public repository, resolves `refs/pull/{n}/head`,
+ * and spends none of the sixty REST requests an anonymous hour holds. A caller
+ * with a token goes through the API's tarball endpoint, which is the one of
+ * the two that answers for a private repository; it redirects to a signed
+ * codeload URL, and fetch drops the Authorization header on the cross-origin
+ * hop, which the signed target does not want anyway.
+ */
+export async function githubArchive(
+  owner: string,
+  repo: string,
+  ref: string,
+  token: string | undefined
+): Promise<Response> {
+  const encodedRef = encodeRefForPath(ref);
+  const url =
+    token == null
+      ? `${GITHUB_CODELOAD_HOST}/${owner}/${repo}/tar.gz/${encodedRef}`
+      : `${GITHUB_API_ROOT}/repos/${owner}/${repo}/tarball/${encodedRef}`;
+  const response = await fetch(url, {
+    cache: 'no-store',
+    headers:
+      token == null
+        ? { accept: 'application/x-gzip', 'user-agent': USER_AGENT }
+        : headers(token, JSON_MEDIA_TYPE),
+    redirect: 'follow',
+  });
+  if (!response.ok) {
+    throw new GitHubError(
+      rateLimitedStatus(response.status, response.headers),
+      // codeload answers a missing ref and an invisible repository alike with
+      // a bare 404 and no sentence of its own, so the caller writes one.
+      response.status === 404
+        ? 'GitHub has no archive for that commit. A private repository needs a token.'
+        : await readErrorMessage(response)
+    );
+  }
+  return response;
+}
+
 // --- Where one file's contents comes from ------------------------------------
 
 const GITHUB_RAW_HOST = 'https://raw.githubusercontent.com';

--- a/src/lib/storageKeys.ts
+++ b/src/lib/storageKeys.ts
@@ -11,6 +11,7 @@ export const RAIL_COLLAPSED_STORAGE_KEY = 'ghdiff-rail-collapsed';
 export const SIDEBAR_WIDTH_STORAGE_KEY = 'ghdiff-sidebar-width';
 export const RAIL_WIDTH_STORAGE_KEY = 'ghdiff-rail-width';
 export const COMMENT_AUTHOR_FILTER_STORAGE_KEY = 'ghdiff-comment-authors';
+export const ARCHIVE_HYDRATION_STORAGE_KEY = 'ghdiff-archive-hydration';
 
 /** Comments for one review target, when they cannot go to GitHub. */
 export function localCommentsStorageKey(targetKey: string): string {

--- a/src/lib/tar.test.ts
+++ b/src/lib/tar.test.ts
@@ -1,0 +1,239 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { type TarEntryHeader, TarReader, type TarSink } from './tar.ts';
+
+// The archives under test are built here, byte by byte, to the same POSIX
+// ustar layout `git archive` writes: fixed-width headers, data padded to the
+// 512-byte block, pax records for what the fixed fields cannot carry, and two
+// zero blocks at the end.
+
+const BLOCK = 512;
+const encoder = new TextEncoder();
+
+function writeString(block: Uint8Array, offset: number, text: string): void {
+  block.set(encoder.encode(text), offset);
+}
+
+function writeOctal(
+  block: Uint8Array,
+  offset: number,
+  length: number,
+  value: number
+): void {
+  writeString(block, offset, value.toString(8).padStart(length - 1, '0'));
+}
+
+function header(
+  name: string,
+  size: number,
+  options: { typeflag?: string; prefix?: string } = {}
+): Uint8Array {
+  const block = new Uint8Array(BLOCK);
+  writeString(block, 0, name);
+  writeOctal(block, 100, 8, 0o644);
+  writeOctal(block, 108, 8, 0);
+  writeOctal(block, 116, 8, 0);
+  writeOctal(block, 124, 12, size);
+  writeOctal(block, 136, 12, 0);
+  writeString(block, 148, '        ');
+  writeString(block, 156, options.typeflag ?? '0');
+  writeString(block, 257, 'ustar');
+  writeString(block, 263, '00');
+  if (options.prefix != null) writeString(block, 345, options.prefix);
+  // The checksum is the byte sum with its own field read as spaces.
+  let sum = 0;
+  for (const byte of block) sum += byte;
+  writeOctal(block, 148, 7, sum);
+  block[155] = 0x20;
+  return block;
+}
+
+function data(contents: string): Uint8Array {
+  const bytes = encoder.encode(contents);
+  const padded = new Uint8Array(Math.ceil(bytes.length / BLOCK) * BLOCK);
+  padded.set(bytes);
+  return padded;
+}
+
+function file(
+  name: string,
+  contents: string,
+  options: { prefix?: string } = {}
+): Uint8Array[] {
+  const bytes = encoder.encode(contents);
+  return [header(name, bytes.length, options), data(contents)];
+}
+
+function paxHeader(records: Record<string, string>): Uint8Array[] {
+  let text = '';
+  for (const [key, value] of Object.entries(records)) {
+    const body = ` ${key}=${value}\n`;
+    // The length prefix counts itself, so it is found by fixpoint: almost
+    // every record settles in one step and a carry settles in two.
+    let length = body.length + 1;
+    while (`${length}${body}`.length !== length) {
+      length = `${length}${body}`.length;
+    }
+    text += `${length}${body}`;
+  }
+  return [
+    header('pax', encoder.encode(text).length, { typeflag: 'x' }),
+    data(text),
+  ];
+}
+
+function archive(...parts: Uint8Array[][]): Uint8Array {
+  const blocks = [
+    ...parts.flat(),
+    new Uint8Array(BLOCK),
+    new Uint8Array(BLOCK),
+  ];
+  const total = blocks.reduce((sum, block) => sum + block.length, 0);
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const block of blocks) {
+    bytes.set(block, offset);
+    offset += block.length;
+  }
+  return bytes;
+}
+
+class RecordingSink implements TarSink {
+  offered: TarEntryHeader[] = [];
+  kept = new Map<string, string>();
+  accept: (header: TarEntryHeader) => boolean;
+
+  constructor(accept: (header: TarEntryHeader) => boolean = () => true) {
+    this.accept = accept;
+  }
+
+  wants(entry: TarEntryHeader): boolean {
+    this.offered.push(entry);
+    return this.accept(entry);
+  }
+
+  onFile(path: string, bytes: Uint8Array): void {
+    this.kept.set(path, new TextDecoder().decode(bytes));
+  }
+}
+
+/** Runs the reader over the archive in slices of the given size. */
+function read(
+  bytes: Uint8Array,
+  sink: TarSink,
+  chunkSize = bytes.length
+): void {
+  const reader = new TarReader(sink);
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    reader.push(
+      bytes.subarray(offset, Math.min(offset + chunkSize, bytes.length))
+    );
+  }
+  reader.end();
+}
+
+test('reads a file whole', () => {
+  const sink = new RecordingSink();
+  read(archive(file('repo/src/a.ts', 'const a = 1;\n')), sink);
+  assert.deepEqual([...sink.kept], [['repo/src/a.ts', 'const a = 1;\n']]);
+});
+
+test('every chunk boundary lands somewhere safe', () => {
+  const bytes = archive(
+    file('repo/a.txt', 'first\n'),
+    file('repo/b.txt', 'x'.repeat(600)),
+    file('repo/c.txt', '')
+  );
+  for (const chunkSize of [1, 7, BLOCK - 1, BLOCK, BLOCK + 1]) {
+    const sink = new RecordingSink();
+    read(bytes, sink, chunkSize);
+    assert.equal(sink.kept.get('repo/a.txt'), 'first\n');
+    assert.equal(sink.kept.get('repo/b.txt'), 'x'.repeat(600));
+    assert.equal(sink.kept.get('repo/c.txt'), '');
+  }
+});
+
+test('a refused file costs no delivery and no offer of its bytes', () => {
+  const sink = new RecordingSink((entry) => entry.path !== 'repo/big.bin');
+  read(
+    archive(
+      file('repo/big.bin', 'y'.repeat(2000)),
+      file('repo/keep.txt', 'kept')
+    ),
+    sink
+  );
+  assert.deepEqual([...sink.kept.keys()], ['repo/keep.txt']);
+  assert.deepEqual(
+    sink.offered.map((entry) => entry.path),
+    ['repo/big.bin', 'repo/keep.txt']
+  );
+});
+
+test('a directory is never offered', () => {
+  const sink = new RecordingSink();
+  read(
+    archive(
+      [header('repo/src/', 0, { typeflag: '5' })],
+      file('repo/src/a.ts', 'a')
+    ),
+    sink
+  );
+  assert.deepEqual(
+    sink.offered.map((entry) => entry.path),
+    ['repo/src/a.ts']
+  );
+});
+
+test('a pax path record overrides the fixed field', () => {
+  const longPath = `repo/${'directory/'.repeat(15)}file.ts`;
+  const sink = new RecordingSink();
+  read(
+    archive(paxHeader({ path: longPath }), file('repo/truncated', 'deep')),
+    sink
+  );
+  assert.deepEqual([...sink.kept], [[longPath, 'deep']]);
+});
+
+test('a pax global header is consumed and changes nothing', () => {
+  const sink = new RecordingSink();
+  const global = [
+    header('pax_global_header', 18, { typeflag: 'g' }),
+    data('18 comment=abc123\n'),
+  ];
+  read(archive(global, file('repo/a.txt', 'after')), sink);
+  assert.deepEqual([...sink.kept], [['repo/a.txt', 'after']]);
+});
+
+test('the ustar prefix field joins the path', () => {
+  const sink = new RecordingSink();
+  read(archive(file('file.ts', 'split', { prefix: 'repo/deep/dir' })), sink);
+  assert.deepEqual([...sink.kept], [['repo/deep/dir/file.ts', 'split']]);
+});
+
+test('a truncated archive throws from end', () => {
+  const bytes = archive(file('repo/a.txt', 'z'.repeat(600)));
+  const sink = new RecordingSink();
+  const reader = new TarReader(sink);
+  reader.push(bytes.subarray(0, BLOCK + 100));
+  assert.throws(() => reader.end(), /middle of an entry/);
+});
+
+test('an end without the two zero blocks is accepted', () => {
+  const parts = file('repo/a.txt', 'ok');
+  const bytes = new Uint8Array(parts[0].length + parts[1].length);
+  bytes.set(parts[0], 0);
+  bytes.set(parts[1], parts[0].length);
+  const sink = new RecordingSink();
+  read(bytes, sink);
+  assert.equal(sink.kept.get('repo/a.txt'), 'ok');
+});
+
+test('bytes that are not a tar throw', () => {
+  const sink = new RecordingSink();
+  const reader = new TarReader(sink);
+  assert.throws(
+    () => reader.push(encoder.encode('a'.repeat(BLOCK))),
+    /not a tar/
+  );
+});

--- a/src/lib/tar.ts
+++ b/src/lib/tar.ts
@@ -1,0 +1,283 @@
+// Reading a tar stream one chunk at a time.
+//
+// GitHub's archive endpoints answer with a gzip stream around a tar of a whole
+// worktree, and the browser walks it looking for a handful of changed files.
+// The walk has to be incremental — a chunk arrives, it is consumed, and nothing
+// waits for the whole body — and it has to skip without buffering, because
+// almost every entry in the archive is a file nobody asked for and holding it
+// would cost the memory of the repository rather than of the diff.
+//
+// So the reader keeps at most one 512-byte header, one pax record set, and the
+// bytes of the one file its sink said yes to. Everything else is a counter
+// that eats incoming bytes. The sink is asked before an entry's data arrives,
+// with the entry's size, which is what lets it refuse a file for being too
+// large without paying for a single byte of it.
+//
+// The format is the POSIX ustar layout that `git archive` writes: fixed-width
+// headers in 512-byte blocks, data padded to the block, pax extended headers
+// (`x`) for paths longer than the fixed fields, one pax global header (`g`)
+// carrying the commit id, and two zero blocks at the end. GNU extensions this
+// app will never meet — base-256 sizes, `L` long-name entries — are treated as
+// corruption rather than half-supported.
+
+const BLOCK_SIZE = 512;
+
+/**
+ * A pax record set is a few short `key=value` lines. One claiming to be larger
+ * than this is not metadata, it is a stream this reader has lost its place in.
+ */
+const MAX_PAX_BYTES = 1024 * 1024;
+
+export interface TarEntryHeader {
+  /** The path exactly as the archive wrote it, root directory included. */
+  path: string;
+  /** The entry's content size in bytes. */
+  size: number;
+}
+
+export interface TarSink {
+  /**
+   * Asked once per regular file, before any of its bytes arrive. False skips
+   * the file without buffering it.
+   */
+  wants(header: TarEntryHeader): boolean;
+  /** One wanted file, complete. */
+  onFile(path: string, bytes: Uint8Array): void;
+}
+
+const decoder = new TextDecoder();
+
+export class TarReader {
+  private readonly sink: TarSink;
+
+  /** Bytes still to discard before the next thing worth reading. */
+  private skip = 0;
+
+  /** The wanted file being filled, or nothing. */
+  private collectPath: string | undefined;
+  private collectBytes: Uint8Array | undefined;
+  private collectFilled = 0;
+  private collectPadding = 0;
+
+  /** The header or pax block being buffered, and how much of it has arrived. */
+  private pending: Uint8Array = new Uint8Array(BLOCK_SIZE);
+  private pendingFilled = 0;
+  private parse: 'header' | 'pax' = 'header';
+  private paxContentSize = 0;
+  private paxGlobal = false;
+
+  /** Overrides a following header's fixed-width fields, from a pax `x` entry. */
+  private paxPath: string | undefined;
+  private paxSize: number | undefined;
+
+  private zeroBlocks = 0;
+  private finished = false;
+
+  constructor(sink: TarSink) {
+    this.sink = sink;
+  }
+
+  push(chunk: Uint8Array): void {
+    let offset = 0;
+    while (offset < chunk.length) {
+      // Everything after the end marker is padding some writers add to round
+      // the stream up; it means nothing and is not an error.
+      if (this.finished) return;
+
+      if (this.skip > 0) {
+        const taken = Math.min(this.skip, chunk.length - offset);
+        this.skip -= taken;
+        offset += taken;
+        continue;
+      }
+
+      if (this.collectBytes != null) {
+        const taken = Math.min(
+          this.collectBytes.length - this.collectFilled,
+          chunk.length - offset
+        );
+        this.collectBytes.set(
+          chunk.subarray(offset, offset + taken),
+          this.collectFilled
+        );
+        this.collectFilled += taken;
+        offset += taken;
+        if (this.collectFilled === this.collectBytes.length) {
+          const path = this.collectPath;
+          const bytes = this.collectBytes;
+          this.collectPath = undefined;
+          this.collectBytes = undefined;
+          this.skip = this.collectPadding;
+          if (path != null) this.sink.onFile(path, bytes);
+        }
+        continue;
+      }
+
+      const taken = Math.min(
+        this.pending.length - this.pendingFilled,
+        chunk.length - offset
+      );
+      this.pending.set(
+        chunk.subarray(offset, offset + taken),
+        this.pendingFilled
+      );
+      this.pendingFilled += taken;
+      offset += taken;
+      if (this.pendingFilled < this.pending.length) return;
+
+      const block = this.pending;
+      this.pending = new Uint8Array(BLOCK_SIZE);
+      this.pendingFilled = 0;
+      if (this.parse === 'header') {
+        this.readHeader(block);
+      } else {
+        this.parse = 'header';
+        this.readPax(block);
+      }
+    }
+  }
+
+  /**
+   * Call once the stream ends. Throws when the archive stopped mid-entry,
+   * which is what a capped or dropped download looks like from here. A stream
+   * that ends cleanly between entries but without the two zero blocks is
+   * accepted: some writers leave them off.
+   */
+  end(): void {
+    if (this.finished) return;
+    if (
+      this.collectBytes != null ||
+      this.skip > 0 ||
+      this.pendingFilled > 0 ||
+      this.parse === 'pax'
+    ) {
+      throw new Error('The archive ended in the middle of an entry.');
+    }
+  }
+
+  private readHeader(block: Uint8Array): void {
+    if (isZeroBlock(block)) {
+      this.zeroBlocks += 1;
+      if (this.zeroBlocks === 2) this.finished = true;
+      return;
+    }
+    if (this.zeroBlocks > 0) {
+      throw new Error('The archive continued after its end marker.');
+    }
+    // 'ustar' at offset 257 is the one fixed point of the format; a block
+    // without it means the reader and the stream have come apart.
+    if (readString(block, 257, 5) !== 'ustar') {
+      throw new Error('That is not a tar header.');
+    }
+
+    const size = this.paxSize ?? readOctal(block, 124, 12);
+    const padding = (BLOCK_SIZE - (size % BLOCK_SIZE)) % BLOCK_SIZE;
+    const typeflag = block[156];
+
+    // 'x' describes the next entry, 'g' describes every following one. Both
+    // carry their records as data; only 'x' is worth parsing, since the global
+    // one holds nothing but the commit id.
+    if (typeflag === 0x78 || typeflag === 0x67) {
+      if (size > MAX_PAX_BYTES) {
+        throw new Error('That pax header is too large to be one.');
+      }
+      this.parse = 'pax';
+      this.paxContentSize = size;
+      this.paxGlobal = typeflag === 0x67;
+      this.paxSize = undefined;
+      this.pending = new Uint8Array(size + padding);
+      this.pendingFilled = 0;
+      return;
+    }
+
+    const path = this.paxPath ?? readName(block);
+    this.paxPath = undefined;
+    this.paxSize = undefined;
+
+    // '0' and NUL are the two spellings of a regular file. Directories,
+    // symlinks and the rest have nothing this app wants; their data — usually
+    // none — is skipped like any other.
+    const isFile = typeflag === 0x30 || typeflag === 0;
+    if (isFile && this.sink.wants({ path, size })) {
+      if (size === 0) {
+        this.sink.onFile(path, new Uint8Array(0));
+      } else {
+        this.collectPath = path;
+        this.collectBytes = new Uint8Array(size);
+        this.collectFilled = 0;
+        this.collectPadding = padding;
+      }
+      return;
+    }
+    this.skip = size + padding;
+  }
+
+  private readPax(block: Uint8Array): void {
+    if (this.paxGlobal) return;
+    // Records are `<length> <key>=<value>\n`, where the length counts the
+    // whole record, its own digits included. The value is UTF-8 and may hold
+    // an `=`, so only the first one splits.
+    let offset = 0;
+    while (offset < this.paxContentSize) {
+      let digitsEnd = offset;
+      while (digitsEnd < this.paxContentSize && block[digitsEnd] !== 0x20) {
+        digitsEnd += 1;
+      }
+      const length = Number(readString(block, offset, digitsEnd - offset));
+      if (!Number.isInteger(length) || length <= digitsEnd - offset + 2) {
+        throw new Error('That pax record does not parse.');
+      }
+      const record = decoder.decode(
+        block.subarray(digitsEnd + 1, offset + length - 1)
+      );
+      const equals = record.indexOf('=');
+      if (equals > 0) {
+        const key = record.slice(0, equals);
+        const value = record.slice(equals + 1);
+        if (key === 'path') this.paxPath = value;
+        if (key === 'size') this.paxSize = Number(value);
+      }
+      offset += length;
+    }
+  }
+}
+
+function isZeroBlock(block: Uint8Array): boolean {
+  for (const byte of block) {
+    if (byte !== 0) return false;
+  }
+  return true;
+}
+
+/** The UTF-8 text of a fixed-width field, up to its first NUL. */
+function readString(block: Uint8Array, offset: number, length: number): string {
+  let end = offset;
+  const limit = offset + length;
+  while (end < limit && block[end] !== 0) end += 1;
+  return decoder.decode(block.subarray(offset, end));
+}
+
+/**
+ * A numeric field is octal digits, possibly led by spaces and ended by a space
+ * or NUL. A first byte with the high bit set is GNU's base-256 form for sizes
+ * past 8 GiB, which no archive this app reads should contain.
+ */
+function readOctal(block: Uint8Array, offset: number, length: number): number {
+  const first = block[offset];
+  if (first != null && (first & 0x80) !== 0) {
+    throw new Error('That tar header uses a size format this reader does not.');
+  }
+  const text = readString(block, offset, length).trim();
+  const value = Number.parseInt(text === '' ? '0' : text, 8);
+  if (Number.isNaN(value)) {
+    throw new Error('That tar header does not parse.');
+  }
+  return value;
+}
+
+/** The entry path from the fixed fields: prefix, a slash, then the name. */
+function readName(block: Uint8Array): string {
+  const name = readString(block, 0, 100);
+  const prefix = readString(block, 345, 155);
+  return prefix === '' ? name : `${prefix}/${name}`;
+}

--- a/src/lib/viewerControls.test.ts
+++ b/src/lib/viewerControls.test.ts
@@ -34,6 +34,7 @@ describe('acceptViewerControls', () => {
       lineNumbers: false,
       backgrounds: false,
       dimWhitespace: false,
+      markMoves: false,
     };
     assert.deepEqual(acceptViewerControls(stored), stored);
   });

--- a/src/lib/viewerControls.ts
+++ b/src/lib/viewerControls.ts
@@ -20,6 +20,8 @@ export interface ViewerControls {
   backgrounds: boolean;
   /** Dim a changed line whose two sides differ only in whitespace. */
   dimWhitespace: boolean;
+  /** Dim and edge-mark a block that moved within its file unaltered. */
+  markMoves: boolean;
 }
 
 export const DEFAULT_VIEWER_CONTROLS: ViewerControls = {
@@ -29,6 +31,7 @@ export const DEFAULT_VIEWER_CONTROLS: ViewerControls = {
   lineNumbers: true,
   backgrounds: true,
   dimWhitespace: true,
+  markMoves: true,
 };
 
 /** The same set with the one field a phone answers differently. */
@@ -109,6 +112,11 @@ export function acceptViewerControls(
       typeof stored.dimWhitespace === 'boolean',
       stored.dimWhitespace as boolean,
       DEFAULT_VIEWER_CONTROLS.dimWhitespace
+    ),
+    markMoves: take(
+      typeof stored.markMoves === 'boolean',
+      stored.markMoves as boolean,
+      DEFAULT_VIEWER_CONTROLS.markMoves
     ),
   };
   return read === 0 ? undefined : controls;

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as SplatRouteImport } from './routes/$'
+import { Route as ApiArchiveRouteImport } from './routes/api/archive'
 import { Route as ApiDiffRouteImport } from './routes/api/diff'
 import { Route as ApiFileRouteImport } from './routes/api/file'
 import { Route as GhSplatRouteImport } from './routes/gh/$'
@@ -24,6 +25,11 @@ const IndexRoute = IndexRouteImport.update({
 const SplatRoute = SplatRouteImport.update({
   id: '/$',
   path: '/$',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiArchiveRoute = ApiArchiveRouteImport.update({
+  id: '/api/archive',
+  path: '/api/archive',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiDiffRoute = ApiDiffRouteImport.update({
@@ -50,6 +56,7 @@ const ApiRpcSplatRoute = ApiRpcSplatRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/$': typeof SplatRoute
+  '/api/archive': typeof ApiArchiveRoute
   '/api/diff': typeof ApiDiffRoute
   '/api/file': typeof ApiFileRoute
   '/gh/$': typeof GhSplatRoute
@@ -58,6 +65,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/$': typeof SplatRoute
+  '/api/archive': typeof ApiArchiveRoute
   '/api/diff': typeof ApiDiffRoute
   '/api/file': typeof ApiFileRoute
   '/gh/$': typeof GhSplatRoute
@@ -67,6 +75,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/$': typeof SplatRoute
+  '/api/archive': typeof ApiArchiveRoute
   '/api/diff': typeof ApiDiffRoute
   '/api/file': typeof ApiFileRoute
   '/gh/$': typeof GhSplatRoute
@@ -74,16 +83,38 @@ export interface FileRoutesById {
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/$' | '/api/diff' | '/api/file' | '/gh/$' | '/api/rpc/$'
+  fullPaths:
+    | '/'
+    | '/$'
+    | '/api/archive'
+    | '/api/diff'
+    | '/api/file'
+    | '/gh/$'
+    | '/api/rpc/$'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/$' | '/api/diff' | '/api/file' | '/gh/$' | '/api/rpc/$'
+  to:
+    | '/'
+    | '/$'
+    | '/api/archive'
+    | '/api/diff'
+    | '/api/file'
+    | '/gh/$'
+    | '/api/rpc/$'
   id:
-    '__root__' | '/' | '/$' | '/api/diff' | '/api/file' | '/gh/$' | '/api/rpc/$'
+    | '__root__'
+    | '/'
+    | '/$'
+    | '/api/archive'
+    | '/api/diff'
+    | '/api/file'
+    | '/gh/$'
+    | '/api/rpc/$'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   SplatRoute: typeof SplatRoute
+  ApiArchiveRoute: typeof ApiArchiveRoute
   ApiDiffRoute: typeof ApiDiffRoute
   ApiFileRoute: typeof ApiFileRoute
   GhSplatRoute: typeof GhSplatRoute
@@ -104,6 +135,13 @@ declare module '@tanstack/react-router' {
       path: '/$'
       fullPath: '/$'
       preLoaderRoute: typeof SplatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/archive': {
+      id: '/api/archive'
+      path: '/api/archive'
+      fullPath: '/api/archive'
+      preLoaderRoute: typeof ApiArchiveRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/diff': {
@@ -140,6 +178,7 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   SplatRoute: SplatRoute,
+  ApiArchiveRoute: ApiArchiveRoute,
   ApiDiffRoute: ApiDiffRoute,
   ApiFileRoute: ApiFileRoute,
   GhSplatRoute: GhSplatRoute,

--- a/src/routes/api/archive.ts
+++ b/src/routes/api/archive.ts
@@ -1,0 +1,86 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+import { requestLog, toLoggable, withEvlog } from '@/lib/logger';
+import {
+  newSideRef,
+  reviewTargetFromQuery,
+  reviewTargetKey,
+} from '@/lib/reviewTarget';
+import {
+  GitHubError,
+  githubArchive,
+  readGitHubToken,
+} from '@/lib/server/github';
+
+// The whole new side of a review, as one tar.gz of the head commit's worktree.
+//
+// Expanding a hunk's unmodified lines needs whole files, and fetching them one
+// by one priced a review by its file count: three hundred changed files were
+// three hundred requests against an anonymous quota of sixty an hour. An
+// archive is one request for all of them — and for the whole repository too,
+// which is the browser's problem, not this route's: the browser decompresses
+// the stream, keeps the paths the diff names, and stops the download the
+// moment it has them or the moment it has read too much. This route only
+// stands between the browser and a host that allows no cross-origin caller,
+// the same job `/api/diff` does for the web diff host, and it buffers nothing.
+//
+// The old side of every file still costs no request at all:
+// `src/lib/diffHydration.ts` rebuilds it from the new side and the patch.
+
+function textResponse(body: string, status: number): Response {
+  return new Response(body, {
+    status,
+    headers: { 'cache-control': 'no-store', 'content-type': 'text/plain' },
+  });
+}
+
+const getArchive = withEvlog(
+  async ({ request }: { request: Request }): Promise<Response> => {
+    const log = requestLog();
+    const params = new URL(request.url).searchParams;
+    const target = reviewTargetFromQuery(params);
+    if (target == null) {
+      log.set({ outcome: 'invalid-target' });
+      return textResponse('That review target is not valid.', 400);
+    }
+    const ref = newSideRef(target);
+    log.set({
+      target: reviewTargetKey(target),
+      targetKind: target.kind,
+      ref,
+    });
+
+    const token = readGitHubToken(request);
+    log.set({
+      authenticated: token != null,
+      source: token == null ? 'codeload' : 'api-tarball',
+    });
+    try {
+      const response = await githubArchive(
+        target.owner,
+        target.repo,
+        ref,
+        token
+      );
+      log.set({ outcome: 'ok' });
+      return new Response(response.body, {
+        status: 200,
+        headers: {
+          'cache-control': 'no-store',
+          'content-type': 'application/gzip',
+        },
+      });
+    } catch (error) {
+      if (error instanceof GitHubError) {
+        log.set({ outcome: 'error', status: error.status });
+        return textResponse(error.message, error.status);
+      }
+      log.error(toLoggable(error), { step: 'load-archive' });
+      return textResponse('Could not load that archive.', 500);
+    }
+  }
+);
+
+export const Route = createFileRoute('/api/archive')({
+  server: { handlers: { GET: getArchive } },
+});

--- a/src/routes/api/file.ts
+++ b/src/routes/api/file.ts
@@ -3,6 +3,7 @@ import { createFileRoute } from '@tanstack/react-router';
 import { FILE_TOO_LARGE, MAX_FILE_BYTES } from '@/lib/diffHydration';
 import { requestLog, toLoggable, withEvlog } from '@/lib/logger';
 import {
+  newSideRef,
   type ReviewTarget,
   reviewTargetFromQuery,
   reviewTargetKey,
@@ -19,6 +20,9 @@ import {
 //
 // This is what lets a reviewer expand the unmodified lines around a hunk: a
 // patch carries three lines of context and the viewer needs the whole file.
+// `/api/archive` is the primary way those files travel — the whole new side in
+// one request — and this route is the fallback the browser reaches for when
+// the archive failed, ran past a cap, or never held the path.
 // It is a route and not an RPC procedure for the same reason `/api/diff` is
 // one — the body is a file, the Worker hands GitHub's own stream straight to
 // the browser, and a JSON envelope would make it read all of it into memory
@@ -40,30 +44,6 @@ function textResponse(body: string, status: number): Response {
     status,
     headers: { 'cache-control': 'no-store', 'content-type': 'text/plain' },
   });
-}
-
-/**
- * The commit whose copy of a file the patch's new side describes.
- *
- * A pull request answers through `refs/pull/{n}/head`, which GitHub keeps in
- * the base repository and which needs no second request to resolve — and works
- * for a pull request from a fork, where the head commit lives nowhere else this
- * route can reach.
- *
- * A compare range answers with whatever it was addressed by. That is a branch
- * or a sha of this repository for every range ghdiff has a link to, and it is
- * `owner:branch` for a range typed across two forks — which neither source
- * below can read, so such a range gets no unmodified lines and says so.
- */
-function newSideRef(target: ReviewTarget): string {
-  switch (target.kind) {
-    case 'github-pull':
-      return `refs/pull/${target.number}/head`;
-    case 'github-commit':
-      return target.sha;
-    case 'github-compare':
-      return target.head;
-  }
 }
 
 /**


### PR DESCRIPTION
Three additions on top of the whitespace dim. A block of three or more
lines that moved unaltered within its file — indentation aside, with git's
own --color-moved floor of twenty significant characters — is dimmed and
edge-marked on both ends. Each hunk separator names the scope git wrote
after @@, which the renderer used to drop. And the expand controls stop
paying one request per file: the first expansion downloads one tar.gz of
the head commit's worktree, a streamed tar reader keeps exactly the changed
paths and cancels the rest, and /api/file stays as the per-file fallback.
The display menu gains switches for the moved marks and the archive.

Part of #4

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>