### PR TITLE
feat(header): the review button says merged or closed

### DIFF
--- a/src/components/ReviewHeader.tsx
+++ b/src/components/ReviewHeader.tsx
@@ -12,6 +12,8 @@ import {
   IconSymbolDiffstat,
   IconX,
 } from '@pierre/icons';
+import { GitMergeIcon } from '@primer/octicons-react/GitMergeIcon';
+import { GitPullRequestClosedIcon } from '@primer/octicons-react/GitPullRequestClosedIcon';
 import { Link } from '@tanstack/react-router';
 import { useState } from 'react';
 
@@ -20,6 +22,7 @@ import { GitHubAccountControl } from '@/components/GitHubAccountControl';
 import { GitHubTextLink } from '@/components/GitHubLink';
 import { PullDetailsCard } from '@/components/PullDetailsCard';
 import { PullListButton } from '@/components/PullListButton';
+import { pullStateLabel } from '@/components/PullStateIcon';
 import { ReviewSubmitDialog } from '@/components/ReviewSubmitDialog';
 import { Button } from '@/components/ui/Button';
 import {
@@ -40,6 +43,7 @@ import type { PullDetailsState } from '@/hooks/usePullDetails';
 import type { SubmitReviewState } from '@/hooks/useSubmitReview';
 import { cn } from '@/lib/cn';
 import { CODE_FONTS, type CodeFontId } from '@/lib/codeFonts';
+import type { PullState } from '@/lib/pulls';
 import type { StatusTone } from '@/lib/pullStatus';
 import {
   describeSubmittedReview,
@@ -168,7 +172,11 @@ export function ReviewHeader({
             range have no thread on GitHub for a verdict to land in. */}
         {review != null && (
           <>
-            <ReviewButton review={review} onOpen={() => setReviewing(true)} />
+            <ReviewButton
+              review={review}
+              state={pull?.data?.state}
+              onOpen={() => setReviewing(true)}
+            />
             <ReviewSubmitDialog
               open={reviewing}
               // Both halves are already in scope: the author arrives with the
@@ -341,6 +349,23 @@ const VERDICT_COLOR: Record<StatusTone, string> = {
   neutral: 'text-status-neutral',
 };
 
+// A merge or a close outranks any verdict: it is what has happened to the pull
+// request since, and it is true for a viewer who never reviewed it too.
+const SETTLED: Partial<
+  Record<PullState, { icon: typeof GitMergeIcon; color: string; title: string }>
+> = {
+  merged: {
+    icon: GitMergeIcon,
+    color: 'text-pr-merged',
+    title: 'This pull request was merged. Review it anyway.',
+  },
+  closed: {
+    icon: GitPullRequestClosedIcon,
+    color: 'text-pr-closed',
+    title: 'This pull request was closed. Review it anyway.',
+  },
+};
+
 /**
  * The way in to a verdict, and the report of the one already on record.
  *
@@ -353,12 +378,24 @@ const VERDICT_COLOR: Record<StatusTone, string> = {
 function ReviewButton({
   onOpen,
   review,
+  state,
 }: {
   onOpen(): void;
   review: SubmitReviewState;
+  state?: PullState;
 }) {
   const { latest } = review;
   const verdict = reviewVerdict(latest);
+
+  const settled = state == null ? undefined : SETTLED[state];
+  if (state != null && settled != null) {
+    return (
+      <Button size="sm" title={settled.title} variant="chrome" onClick={onOpen}>
+        <settled.icon className={cn('shrink-0', settled.color)} size={14} />
+        {pullStateLabel(state)}
+      </Button>
+    );
+  }
 
   // Also the first paint of every review, before GitHub has answered. The
   // button is pressable throughout, because the verdict on record changes what


### PR DESCRIPTION
The review button in the header reported only the viewer's own verdict, so a merged pull request went on reading **Approved**, and a closed one **Review**.

A merge or a close is what has happened to the pull request since any verdict, and it holds for a viewer who never reviewed it and for one who is signed out, so it now outranks the verdict. The icon and colour are the ones `PullStateIcon` already draws for the same two states (`text-pr-merged`, `text-pr-closed`), and the label comes from `pullStateLabel`, so the mapping still lives in one place.

The button still opens the same dialog. GitHub takes a review on a closed pull request, and stays the authority on what it accepts.

| State | Header |
| --- | --- |
| Open (unchanged) | ![Review](https://raw.githubusercontent.com/StableFluffy/ghdiff/screenshots/header-settled-state/open.png) |
| Merged | ![Merged](https://raw.githubusercontent.com/StableFluffy/ghdiff/screenshots/header-settled-state/merged.png) |
| Closed | ![Closed](https://raw.githubusercontent.com/StableFluffy/ghdiff/screenshots/header-settled-state/closed.png) |

Verified with oxfmt, oxlint, tsc and the unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
