### PR TITLE
feat(diff): describe cron schedules beside code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -803,9 +803,9 @@ display-menu switch costs no render at all: the stamps stay, and
 through the shadow boundary — is the whole toggle, the same trick `usePaneWidth`
 plays. Marks are cached in a WeakMap per metadata object, which hydration
 mutates in place and a filter change reuses, so an entry cannot go stale.
-`fileDiffCache` is protected in the library's types and a plain getter at
-runtime; the cast in `ReviewViewer` is the one place that leans on it, and a
-library upgrade must re-check it.
+`CodeView` adds the current item context as `onPostRender`'s fourth argument, so
+`ReviewViewer` passes `item.fileDiff` to both annotation passes through that
+public contract rather than reaching into the renderer's protected cache.
 
 One thing GitHub decides rather than this app: a line comment written on an
 expanded line of a **pull request** is a line outside the diff, and the review
@@ -816,18 +816,24 @@ and take them anywhere.
 
 **A cron expression says when it runs beside the code.** `src/lib/cron.ts`
 recognizes whole quoted literals, bare `cron` / `schedule` fields, and entries
-in `crontab`, `*.cron`, and `cron.d/` files. It validates standard five-field
-cron before handing it to the English-only `cronstrue` entry: that library
-describes schedules but does not validate them. Six- and seven-field dialects
-are left alone rather than guessing whether a field is seconds or a year. Named
-months and weekdays, lists, ranges, steps and standard aliases are read;
-`@reboot` names startup rather than inventing a period.
+in `crontab`, `*.cron`, and `cron.d/` files. A syntax gate keeps the input to
+standard five-field cron, then `cron-schedule` validates and expands it into
+sorted, distinct field values. The gate is necessary even with a parser:
+`cron-schedule` accepts numeric prefixes such as `1W` as 1. `normalizeField`
+turns the parsed values into concise input for the English-only `cronstrue`
+descriptor, which does not validate schedules itself. Six- and seven-field
+dialects are left alone rather than guessing whether a field is seconds or a
+year. Named months and weekdays, lists, ranges, steps and standard aliases are
+read; `@reboot` names startup rather than inventing a period.
 
 Two readings need more than the library's default words. A step resets at the
 field boundary, so `*/35` is minute 0 and 35 of each hour, not an interval of 35
-minutes. And restricted day-of-month and day-of-week fields are OR in standard
-cron, so their descriptions are explicitly joined with **or**. No timezone is
-inferred from the reviewer's browser.
+minutes. Overlapping lists and Sunday aliases are deduplicated before a
+description is written. Restricted day-of-month and day-of-week fields are OR in
+standard cron, so their descriptions are explicitly joined with **or**. That
+decision uses the original fields: Vixie cron records a leading star, not a star
+anywhere in a list, and normalization must not erase that distinction. No
+timezone is inferred from the reviewer's browser.
 
 `diffCronSchedules.ts` uses the same `onPostRender` and `unsafeCSS` seam as the
 whitespace marks. It reads only rendered rows and caches by node, text and path,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -814,6 +814,30 @@ strip along the foot of the screen, which is where every other comment failure
 already lands. A commit and a compare range keep their comments in the browser
 and take them anywhere.
 
+**A cron expression says when it runs beside the code.** `src/lib/cron.ts`
+recognizes whole quoted literals, bare `cron` / `schedule` fields, and entries
+in `crontab`, `*.cron`, and `cron.d/` files. It validates standard five-field
+cron before handing it to the English-only `cronstrue` entry: that library
+describes schedules but does not validate them. Six- and seven-field dialects
+are left alone rather than guessing whether a field is seconds or a year. Named
+months and weekdays, lists, ranges, steps and standard aliases are read;
+`@reboot` names startup rather than inventing a period.
+
+Two readings need more than the library's default words. A step resets at the
+field boundary, so `*/35` is minute 0 and 35 of each hour, not an interval of 35
+minutes. And restricted day-of-month and day-of-week fields are OR in standard
+cron, so their descriptions are explicitly joined with **or**. No timezone is
+inferred from the reviewer's browser.
+
+`diffCronSchedules.ts` uses the same `onPostRender` and `unsafeCSS` seam as the
+whitespace marks. It reads only rendered rows and caches by node, text and path,
+so highlighting, hydration and virtualized replacements get a fresh answer. The
+hint is absolutely positioned generated content after the code: it changes
+neither the source text selected for copying nor the virtualizer's line height.
+A narrow pane clips the hint; the row's native tooltip holds the complete
+expression, description and timezone caveat. Split and unified views use the
+same path, including deleted lines.
+
 **The wait says how much has arrived, and never how much is left.** A patch of
 tens of megabytes is a long stare at one sentence — oven-sh/bun#30412 is 43.3 MB
 in 1,654 chunks over four seconds — so `useReviewPatch` reads the body through

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@tanstack/react-router": "^1.170.32",
     "@tanstack/react-start": "^1.168.49",
     "clsx": "^2.1.1",
+    "cron-schedule": "6.0.0",
     "cronstrue": "^3.24.0",
     "evlog": "^2.27.0",
     "jotai": "^2.20.3",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@tanstack/react-router": "^1.170.32",
     "@tanstack/react-start": "^1.168.49",
     "clsx": "^2.1.1",
+    "cronstrue": "^3.24.0",
     "evlog": "^2.27.0",
     "jotai": "^2.20.3",
     "react": "^19.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      cron-schedule:
+        specifier: 6.0.0
+        version: 6.0.0
       cronstrue:
         specifier: ^3.24.0
         version: 3.24.0
@@ -2207,6 +2210,10 @@ packages:
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  cron-schedule@6.0.0:
+    resolution: {integrity: sha512-BoZaseYGXOo5j5HUwTaegIog3JJbuH4BbrY9A1ArLjXpy+RWb3mV28F/9Gv1dDA7E2L8kngWva4NWisnLTyfgQ==}
+    engines: {node: '>=20'}
 
   cronstrue@3.24.0:
     resolution: {integrity: sha512-t/Ji3Ur2c/pzhIAWNwC0ftl3JAE4dLfCjAdZoTZXmPDZwcispnS1PaMcMS4OmIIXyIVouAz+yw+mfQiE3hz5OQ==}
@@ -4958,6 +4965,8 @@ snapshots:
   cookie-es@3.1.1: {}
 
   cookie@1.1.1: {}
+
+  cron-schedule@6.0.0: {}
 
   cronstrue@3.24.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      cronstrue:
+        specifier: ^3.24.0
+        version: 3.24.0
       evlog:
         specifier: ^2.27.0
         version: 2.27.0(@orpc/server@1.15.0(ws@8.21.0))(@tanstack/start-client-core@1.170.27)(next@16.3.2(@babel/core@7.29.7)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0))
@@ -2204,6 +2207,10 @@ packages:
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  cronstrue@3.24.0:
+    resolution: {integrity: sha512-t/Ji3Ur2c/pzhIAWNwC0ftl3JAE4dLfCjAdZoTZXmPDZwcispnS1PaMcMS4OmIIXyIVouAz+yw+mfQiE3hz5OQ==}
+    hasBin: true
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -4951,6 +4958,8 @@ snapshots:
   cookie-es@3.1.1: {}
 
   cookie@1.1.1: {}
+
+  cronstrue@3.24.0: {}
 
   csstype@3.2.3: {}
 

--- a/src/components/ReviewViewer.tsx
+++ b/src/components/ReviewViewer.tsx
@@ -16,6 +16,10 @@ import { memo, type RefObject, useCallback, useMemo } from 'react';
 
 import { CommentComposer } from '@/components/CommentComposer';
 import { CommentThreadCard } from '@/components/CommentThreadCard';
+import {
+  applyCronSchedules,
+  CRON_SCHEDULES_CSS,
+} from '@/components/diffCronSchedules';
 import { applyLineMarks, LINE_MARKS_CSS } from '@/components/diffLineMarks';
 import { Button } from '@/components/ui/Button';
 import { Tooltip } from '@/components/ui/Tooltip';
@@ -153,7 +157,7 @@ export const ReviewViewer = memo(function ReviewViewer({
       },
       // The stylesheet for the marks below, installed by the library inside
       // each file's shadow root, where no outside selector can reach.
-      unsafeCSS: LINE_MARKS_CSS,
+      unsafeCSS: LINE_MARKS_CSS + CRON_SCHEDULES_CSS,
       onPostRender(node, instance, phase) {
         if (phase === 'unmount') return;
         // `fileDiffCache` is protected in the type and a plain getter at
@@ -162,6 +166,7 @@ export const ReviewViewer = memo(function ReviewViewer({
           instance as unknown as { fileDiffCache?: FileDiffMetadata }
         ).fileDiffCache;
         applyLineMarks(node, fileDiff);
+        applyCronSchedules(node, fileDiff);
       },
     }),
     [

--- a/src/components/ReviewViewer.tsx
+++ b/src/components/ReviewViewer.tsx
@@ -158,15 +158,10 @@ export const ReviewViewer = memo(function ReviewViewer({
       // The stylesheet for the marks below, installed by the library inside
       // each file's shadow root, where no outside selector can reach.
       unsafeCSS: LINE_MARKS_CSS + CRON_SCHEDULES_CSS,
-      onPostRender(node, instance, phase) {
-        if (phase === 'unmount') return;
-        // `fileDiffCache` is protected in the type and a plain getter at
-        // runtime; there is no public path from an instance to its metadata.
-        const fileDiff = (
-          instance as unknown as { fileDiffCache?: FileDiffMetadata }
-        ).fileDiffCache;
-        applyLineMarks(node, fileDiff);
-        applyCronSchedules(node, fileDiff);
+      onPostRender(node, _instance, phase, { item }) {
+        if (phase === 'unmount' || item.type !== 'diff') return;
+        applyLineMarks(node, item.fileDiff);
+        applyCronSchedules(node, item.fileDiff);
       },
     }),
     [

--- a/src/components/diffCronSchedules.ts
+++ b/src/components/diffCronSchedules.ts
@@ -1,0 +1,60 @@
+import type { FileDiffMetadata } from '@pierre/diffs';
+
+import { findCronSchedules } from '@/lib/cron';
+
+// Generated content leaves the code's text nodes, copy and line anchors alone.
+// Absolute positioning keeps the virtualizer's measured line heights intact,
+// even with wrapping enabled. A narrow pane clips the hint, never the code;
+// the row's native tooltip carries the complete reading and its timezone caveat.
+export const CRON_SCHEDULES_CSS = `
+[data-ghdiff-cron] {
+  position: relative;
+  overflow: clip;
+}
+[data-ghdiff-cron]::after {
+  content: attr(data-ghdiff-cron);
+  position: absolute;
+  padding-inline-start: 1.5em;
+  color: var(--app-ink-muted);
+  font-family: var(--app-font-sans);
+  font-size: 11px;
+  white-space: pre;
+  pointer-events: none;
+  user-select: none;
+}
+`;
+
+// Cache rendered rows, not whole patches. A huge diff pays only for its visible
+// window; a new highlighter pass or hydration changes the text and invalidates it.
+const renderedRows = new WeakMap<HTMLElement, { text: string; path: string }>();
+
+export function applyCronSchedules(
+  container: HTMLElement,
+  fileDiff: FileDiffMetadata | undefined
+): void {
+  if (container.shadowRoot == null || fileDiff == null) return;
+  for (const row of container.shadowRoot.querySelectorAll<HTMLElement>(
+    '[data-line]'
+  )) {
+    const path =
+      row.dataset.lineType === 'change-deletion'
+        ? (fileDiff.prevName ?? fileDiff.name)
+        : fileDiff.name;
+    const text = row.textContent ?? '';
+    const cached = renderedRows.get(row);
+    if (cached?.text === text && cached.path === path) continue;
+    renderedRows.set(row, { text, path });
+    const schedules = findCronSchedules(text, path);
+    if (schedules.length === 0) {
+      if (row.hasAttribute('data-ghdiff-cron')) {
+        row.removeAttribute('data-ghdiff-cron');
+        row.removeAttribute('title');
+      }
+      continue;
+    }
+    row.dataset.ghdiffCron = schedules
+      .map(({ description }) => description)
+      .join(' · ');
+    row.title = `${schedules.map(({ expression, description }) => `${expression} — ${description}`).join('\n')}\nTimes use the scheduler’s timezone, not your browser’s.`;
+  }
+}

--- a/src/lib/cron.test.ts
+++ b/src/lib/cron.test.ts
@@ -59,6 +59,11 @@ describe('cron schedules', () => {
       '0 0 * FOO *',
       '0 0 * * MON#2',
       '0 0 L * *',
+      '0 0 1W * *',
+      '0 0 * * 1#2',
+      '1abc * * * *',
+      '1/5 * * * *',
+      '0 0 * * ?',
       '0 0 * * * trailing',
     ]) {
       assert.equal(describeCron(expression), undefined, expression);
@@ -83,6 +88,8 @@ describe('cron schedules', () => {
     assert.doesNotMatch(describeCron('*/35 * * * *')!, /every 35 minutes/i);
     assert.match(describeCron('0 */23 * * *')!, /00:00.*23:00/);
     assert.match(describeCron('0 0 */2 * *')!, /day 1, 3, 5/);
+    assert.match(describeCron('0,5,10 * * * *')!, /0, 5, and 10 minutes/);
+    assert.doesNotMatch(describeCron('0,5,10 * * * *')!, /every 5 minutes/i);
   });
 
   it('preserves the OR between restricted day fields and Sunday aliases', () => {
@@ -93,7 +100,25 @@ describe('cron schedules', () => {
       assert.ok(weekend.includes(day));
     }
     assert.doesNotMatch(weekend, /Monday|Tuesday|Wednesday|Thursday/);
-    assert.doesNotMatch(describeCron('0 0 * * 0-7')!, /Sunday through Sunday/);
+    assert.equal(describeCron('0 0 * * 0-7'), describeCron('0 0 * * *'));
     assert.match(describeCron('0 0 */2 * MON')!, /day 1, 3.*only on Monday/);
+  });
+
+  it('describes equivalent overlapping fields once', () => {
+    assert.equal(describeCron('0 0 1,1-5 * *'), describeCron('0 0 1-5 * *'));
+    assert.equal(describeCron('0 0 * JAN,MAR *'), describeCron('0 0 * 1,3 *'));
+  });
+
+  it('keeps calendar names on the same month after normalization', () => {
+    assert.match(describeCron('0 0 1 JAN *')!, /January/);
+    assert.match(describeCron('0 0 1 DEC *')!, /December/);
+    assert.equal(describeCron('@midnight'), describeCron('@daily'));
+  });
+
+  it('takes the day-field wildcard flag from the first character', () => {
+    const restricted = describeCron('0 0 1,*/2 * MON')!;
+    assert.match(restricted, /; or .*Monday/);
+    assert.doesNotMatch(restricted, /day 1, 1,/);
+    assert.doesNotMatch(describeCron('0 0 */2,1 * MON')!, /; or /);
   });
 });

--- a/src/lib/cron.test.ts
+++ b/src/lib/cron.test.ts
@@ -3,6 +3,25 @@ import { describe, it } from 'node:test';
 
 import { describeCron, findCronSchedules } from './cron.ts';
 
+const EVERY_FIVE_MINUTES = /every 5 minutes/i;
+const WEEKDAY_MORNING = /09:00.*Monday.*Friday/;
+const WEEKDAY_RANGE = /Monday.*Friday/;
+const EVERY_TEN_MINUTES = /every 10 minutes/i;
+const SYSTEM_STARTUP = /startup/i;
+const MINUTES_ZERO_AND_THIRTY_FIVE = /0 and 35 minutes/;
+const EVERY_THIRTY_FIVE_MINUTES = /every 35 minutes/i;
+const HOURS_ZERO_AND_TWENTY_THREE = /00:00.*23:00/;
+const ODD_CALENDAR_DAYS = /day 1, 3, 5/;
+const MINUTES_ZERO_FIVE_TEN = /0, 5, and 10 minutes/;
+const FIRST_DAY_OR_FRIDAY = /day 1.*; or .*Friday/;
+const MONDAY_THROUGH_THURSDAY = /Monday|Tuesday|Wednesday|Thursday/;
+const ODD_DAYS_ON_MONDAY = /day 1, 3.*only on Monday/;
+const JANUARY = /January/;
+const DECEMBER = /December/;
+const OR_MONDAY = /; or .*Monday/;
+const REPEATED_FIRST_DAY = /day 1, 1,/;
+const DAY_FIELD_DISJUNCTION = /; or /;
+
 describe('cron schedules', () => {
   it('reads literal schedules in configuration and code without needing token boundaries', () => {
     const schedules = findCronSchedules(
@@ -10,11 +29,11 @@ describe('cron schedules', () => {
       'jobs.ts'
     );
     assert.equal(schedules[0]?.expression, '*/5 * * * *');
-    assert.match(schedules[0]!.description, /every 5 minutes/i);
+    assert.match(schedules[0]!.description, EVERY_FIVE_MINUTES);
     assert.match(
       findCronSchedules("  - cron: '0 9 * * MON-FRI'", 'ci.yml')[0]!
         .description,
-      /09:00.*Monday.*Friday/
+      WEEKDAY_MORNING
     );
     assert.equal(
       findCronSchedules('const jobs = ["@daily", `@hourly`];', 'jobs.ts')
@@ -27,16 +46,16 @@ describe('cron schedules', () => {
     assert.match(
       findCronSchedules('0 9 * * 1-5 /usr/bin/run', 'etc/cron.d/jobs')[0]!
         .description,
-      /Monday.*Friday/
+      WEEKDAY_RANGE
     );
     assert.match(
       findCronSchedules('schedule: */10 * * * * # refresh', 'jobs.yml')[0]!
         .description,
-      /every 10 minutes/i
+      EVERY_TEN_MINUTES
     );
     assert.match(
       findCronSchedules('@reboot /usr/bin/run', 'crontab')[0]!.description,
-      /startup/i
+      SYSTEM_STARTUP
     );
     assert.deepEqual(findCronSchedules('* * * * *', 'README.md'), []);
     assert.deepEqual(
@@ -84,24 +103,27 @@ describe('cron schedules', () => {
   });
 
   it('spells out steps that reset rather than claiming a constant interval', () => {
-    assert.match(describeCron('*/35 * * * *')!, /0 and 35 minutes/);
-    assert.doesNotMatch(describeCron('*/35 * * * *')!, /every 35 minutes/i);
-    assert.match(describeCron('0 */23 * * *')!, /00:00.*23:00/);
-    assert.match(describeCron('0 0 */2 * *')!, /day 1, 3, 5/);
-    assert.match(describeCron('0,5,10 * * * *')!, /0, 5, and 10 minutes/);
-    assert.doesNotMatch(describeCron('0,5,10 * * * *')!, /every 5 minutes/i);
+    assert.match(describeCron('*/35 * * * *')!, MINUTES_ZERO_AND_THIRTY_FIVE);
+    assert.doesNotMatch(
+      describeCron('*/35 * * * *')!,
+      EVERY_THIRTY_FIVE_MINUTES
+    );
+    assert.match(describeCron('0 */23 * * *')!, HOURS_ZERO_AND_TWENTY_THREE);
+    assert.match(describeCron('0 0 */2 * *')!, ODD_CALENDAR_DAYS);
+    assert.match(describeCron('0,5,10 * * * *')!, MINUTES_ZERO_FIVE_TEN);
+    assert.doesNotMatch(describeCron('0,5,10 * * * *')!, EVERY_FIVE_MINUTES);
   });
 
   it('preserves the OR between restricted day fields and Sunday aliases', () => {
-    assert.match(describeCron('0 0 1 * FRI')!, /day 1.*; or .*Friday/);
+    assert.match(describeCron('0 0 1 * FRI')!, FIRST_DAY_OR_FRIDAY);
     assert.equal(describeCron('0 0 * * 0'), describeCron('0 0 * * 7'));
     const weekend = describeCron('0 0 * * 5-7')!;
     for (const day of ['Friday', 'Saturday', 'Sunday']) {
       assert.ok(weekend.includes(day));
     }
-    assert.doesNotMatch(weekend, /Monday|Tuesday|Wednesday|Thursday/);
+    assert.doesNotMatch(weekend, MONDAY_THROUGH_THURSDAY);
     assert.equal(describeCron('0 0 * * 0-7'), describeCron('0 0 * * *'));
-    assert.match(describeCron('0 0 */2 * MON')!, /day 1, 3.*only on Monday/);
+    assert.match(describeCron('0 0 */2 * MON')!, ODD_DAYS_ON_MONDAY);
   });
 
   it('describes equivalent overlapping fields once', () => {
@@ -110,15 +132,18 @@ describe('cron schedules', () => {
   });
 
   it('keeps calendar names on the same month after normalization', () => {
-    assert.match(describeCron('0 0 1 JAN *')!, /January/);
-    assert.match(describeCron('0 0 1 DEC *')!, /December/);
+    assert.match(describeCron('0 0 1 JAN *')!, JANUARY);
+    assert.match(describeCron('0 0 1 DEC *')!, DECEMBER);
     assert.equal(describeCron('@midnight'), describeCron('@daily'));
   });
 
   it('takes the day-field wildcard flag from the first character', () => {
     const restricted = describeCron('0 0 1,*/2 * MON')!;
-    assert.match(restricted, /; or .*Monday/);
-    assert.doesNotMatch(restricted, /day 1, 1,/);
-    assert.doesNotMatch(describeCron('0 0 */2,1 * MON')!, /; or /);
+    assert.match(restricted, OR_MONDAY);
+    assert.doesNotMatch(restricted, REPEATED_FIRST_DAY);
+    assert.doesNotMatch(
+      describeCron('0 0 */2,1 * MON')!,
+      DAY_FIELD_DISJUNCTION
+    );
   });
 });

--- a/src/lib/cron.test.ts
+++ b/src/lib/cron.test.ts
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { describeCron, findCronSchedules } from './cron.ts';
+
+describe('cron schedules', () => {
+  it('reads literal schedules in configuration and code without needing token boundaries', () => {
+    const schedules = findCronSchedules(
+      'cron.schedule("*/5 * * * *", run);',
+      'jobs.ts'
+    );
+    assert.equal(schedules[0]?.expression, '*/5 * * * *');
+    assert.match(schedules[0]!.description, /every 5 minutes/i);
+    assert.match(
+      findCronSchedules("  - cron: '0 9 * * MON-FRI'", 'ci.yml')[0]!
+        .description,
+      /09:00.*Monday.*Friday/
+    );
+    assert.equal(
+      findCronSchedules('const jobs = ["@daily", `@hourly`];', 'jobs.ts')
+        .length,
+      2
+    );
+  });
+
+  it('accepts bare cron entries only with file or field context', () => {
+    assert.match(
+      findCronSchedules('0 9 * * 1-5 /usr/bin/run', 'etc/cron.d/jobs')[0]!
+        .description,
+      /Monday.*Friday/
+    );
+    assert.match(
+      findCronSchedules('schedule: */10 * * * * # refresh', 'jobs.yml')[0]!
+        .description,
+      /every 10 minutes/i
+    );
+    assert.match(
+      findCronSchedules('@reboot /usr/bin/run', 'crontab')[0]!.description,
+      /startup/i
+    );
+    assert.deepEqual(findCronSchedules('* * * * *', 'README.md'), []);
+    assert.deepEqual(
+      findCronSchedules('# 0 9 * * * /usr/bin/run', 'crontab'),
+      []
+    );
+  });
+
+  it('never reads part of an unsupported dialect or an invalid expression', () => {
+    for (const expression of [
+      '0 0 9 * * *',
+      '0 0 9 ? * MON *',
+      '60 * * * *',
+      '0 24 * * *',
+      '0 0 0 * *',
+      '0 0 * 13 *',
+      '0 0 * * 8',
+      '*/0 * * * *',
+      '0 9-2 * * *',
+      '0 0 * FOO *',
+      '0 0 * * MON#2',
+      '0 0 L * *',
+      '0 0 * * * trailing',
+    ]) {
+      assert.equal(describeCron(expression), undefined, expression);
+      assert.deepEqual(
+        findCronSchedules(`schedule: "${expression}"`, 'jobs.yml'),
+        [],
+        expression
+      );
+    }
+    assert.deepEqual(
+      findCronSchedules('const words = "run at 0 9 * * * please";', 'jobs.ts'),
+      []
+    );
+    assert.deepEqual(
+      findCronSchedules('const cron = "${minute} * * * *";', 'jobs.ts'),
+      []
+    );
+  });
+
+  it('spells out steps that reset rather than claiming a constant interval', () => {
+    assert.match(describeCron('*/35 * * * *')!, /0 and 35 minutes/);
+    assert.doesNotMatch(describeCron('*/35 * * * *')!, /every 35 minutes/i);
+    assert.match(describeCron('0 */23 * * *')!, /00:00.*23:00/);
+    assert.match(describeCron('0 0 */2 * *')!, /day 1, 3, 5/);
+  });
+
+  it('preserves the OR between restricted day fields and Sunday aliases', () => {
+    assert.match(describeCron('0 0 1 * FRI')!, /day 1.*; or .*Friday/);
+    assert.equal(describeCron('0 0 * * 0'), describeCron('0 0 * * 7'));
+    const weekend = describeCron('0 0 * * 5-7')!;
+    for (const day of ['Friday', 'Saturday', 'Sunday']) {
+      assert.ok(weekend.includes(day));
+    }
+    assert.doesNotMatch(weekend, /Monday|Tuesday|Wednesday|Thursday/);
+    assert.doesNotMatch(describeCron('0 0 * * 0-7')!, /Sunday through Sunday/);
+    assert.match(describeCron('0 0 */2 * MON')!, /day 1, 3.*only on Monday/);
+  });
+});

--- a/src/lib/cron.ts
+++ b/src/lib/cron.ts
@@ -1,3 +1,4 @@
+import { parseCronExpression } from 'cron-schedule';
 import cronstrue from 'cronstrue';
 
 export interface CronSchedule {
@@ -5,15 +6,6 @@ export interface CronSchedule {
   description: string;
 }
 
-const MONTHS = 'JAN FEB MAR APR MAY JUN JUL AUG SEP OCT NOV DEC'.split(' ');
-const DAYS = 'SUN MON TUE WED THU FRI SAT'.split(' ');
-const FIELDS = [
-  { min: 0, max: 59 },
-  { min: 0, max: 23 },
-  { min: 1, max: 31 },
-  { min: 1, max: 12, names: MONTHS },
-  { min: 0, max: 7, names: DAYS },
-];
 const ALIASES: Record<string, string> = {
   '@yearly': '0 0 1 1 *',
   '@annually': '0 0 1 1 *',
@@ -24,6 +16,42 @@ const ALIASES: Record<string, string> = {
   '@hourly': '0 * * * *',
 };
 
+// Restrict syntax before parsing: cron-schedule accepts numeric prefixes such
+// as "1W" as 1. Range validation and expansion belong to the parser, not here.
+const FIELD_PART =
+  /^(?:\*(?:\/\d{1,2})?|(?:\d{1,2}|[a-z]{3})(?:-(?:\d{1,2}|[a-z]{3})(?:\/\d{1,2})?)?)$/i;
+
+// Turn sorted, distinct values back into concise input for the descriptor.
+// Only minutes and hours have fixed cycles: */35 is :00 and :35, whereas
+// */5 really is every five minutes. Calendar fields never become intervals.
+function normalizeField(
+  values: readonly number[],
+  cardinality: number,
+  cyclic = false,
+  offset = 0
+): string {
+  if (values.length === cardinality) return '*';
+  const first = values[0]!;
+  if (values.length > 1) {
+    const step = values[1]! - first;
+    if (
+      cyclic &&
+      first === 0 &&
+      cardinality % step === 0 &&
+      values.length === cardinality / step &&
+      values.every((value, index) => value === index * step)
+    ) {
+      return `*/${step}`;
+    }
+    if (values.every((value, index) => value === first + index)) {
+      return `${first + offset}-${values[values.length - 1]! + offset}`;
+    }
+  }
+  return offset === 0
+    ? values.join(',')
+    : values.map((value) => value + offset).join(',');
+}
+
 /** Validate before describing: cronstrue deliberately is not a validator.
  * Five fields only; a sixth could be seconds OR a year in another dialect. */
 export function describeCron(expression: string): string | undefined {
@@ -33,61 +61,29 @@ export function describeCron(expression: string): string | undefined {
   const fields = (Object.hasOwn(ALIASES, source) ? ALIASES[source]! : source)
     .toUpperCase()
     .split(/\s+/);
-  if (fields.length !== FIELDS.length) return undefined;
-
-  const normalized: string[] = [];
-  for (const [index, field] of fields.entries()) {
-    const { min, max, names } = FIELDS[index]!;
-    const value = (text: string): number => {
-      if (/^\d{1,2}$/.test(text)) return Number(text);
-      const named = names?.indexOf(text) ?? -1;
-      return named < 0 ? NaN : named + min;
-    };
-    const parts: string[] = [];
-    for (const part of field.split(',')) {
-      const match =
-        /^(\*|[A-Z]{3}|\d{1,2})(?:-([A-Z]{3}|\d{1,2}))?(?:\/(\d{1,2}))?$/.exec(
-          part
-        );
-      if (match == null) return undefined;
-      const [, start, end, stepText] = match;
-      if (start === '*' && end != null) return undefined;
-      if (stepText != null && start !== '*' && end == null) return undefined;
-      const low = start === '*' ? min : value(start!);
-      const high = start === '*' ? max : end == null ? low : value(end);
-      const step = stepText == null ? 1 : Number(stepText);
-      if (
-        !Number.isFinite(low) ||
-        !Number.isFinite(high) ||
-        low < min ||
-        high > max ||
-        low > high ||
-        step < 1 ||
-        step > max - min + 1
-      ) {
-        return undefined;
-      }
-      // A step resets at the field boundary. "Every 35 minutes" is false:
-      // */35 runs at :00 and :35, not at a constant 35-minute interval.
-      if (
-        (index === 4 && start !== '*' && high === 7 && end != null) ||
-        (stepText != null &&
-          !(start === '*' && index < 2 && (max + 1) % step === 0))
-      ) {
-        for (let n = low; n <= high; n += step) {
-          parts.push(String(index === 4 ? n % 7 : n));
-        }
-      } else {
-        parts.push(part);
-      }
-    }
-    normalized.push(parts.join(','));
+  if (
+    fields.length !== 5 ||
+    fields.some((field) =>
+      field.split(',').some((part) => !FIELD_PART.test(part))
+    )
+  ) {
+    return undefined;
   }
 
   try {
+    const parsed = parseCronExpression(fields.join(' '));
+    const normalized = [
+      normalizeField(parsed.minutes, 60, true),
+      normalizeField(parsed.hours, 24, true),
+      normalizeField(parsed.days, 31),
+      normalizeField(parsed.months, 12, false, 1),
+      normalizeField(parsed.weekdays, 7),
+    ];
     // Cron's two restricted day fields are OR, not Quartz's AND. Spell it
     // out: cronstrue's default "and on Friday" is easy to read as AND.
-    const bothDays = !fields[2]!.includes('*') && !fields[4]!.includes('*');
+    // Vixie cron records a leading star, not any star in a list. Decide this
+    // before normalization: an explicit full range is not a wildcard flag.
+    const bothDays = !fields[2]!.startsWith('*') && !fields[4]!.startsWith('*');
     const describe = (parts: string[]) =>
       cronstrue.toString(parts.join(' '), {
         use24HourTimeFormat: true,

--- a/src/lib/cron.ts
+++ b/src/lib/cron.ts
@@ -1,0 +1,138 @@
+import cronstrue from 'cronstrue';
+
+export interface CronSchedule {
+  expression: string;
+  description: string;
+}
+
+const MONTHS = 'JAN FEB MAR APR MAY JUN JUL AUG SEP OCT NOV DEC'.split(' ');
+const DAYS = 'SUN MON TUE WED THU FRI SAT'.split(' ');
+const FIELDS = [
+  { min: 0, max: 59 },
+  { min: 0, max: 23 },
+  { min: 1, max: 31 },
+  { min: 1, max: 12, names: MONTHS },
+  { min: 0, max: 7, names: DAYS },
+];
+const ALIASES: Record<string, string> = {
+  '@yearly': '0 0 1 1 *',
+  '@annually': '0 0 1 1 *',
+  '@monthly': '0 0 1 * *',
+  '@weekly': '0 0 * * 0',
+  '@daily': '0 0 * * *',
+  '@midnight': '0 0 * * *',
+  '@hourly': '0 * * * *',
+};
+
+/** Validate before describing: cronstrue deliberately is not a validator.
+ * Five fields only; a sixth could be seconds OR a year in another dialect. */
+export function describeCron(expression: string): string | undefined {
+  if (expression.length > 256) return undefined;
+  const source = expression.trim();
+  if (source === '@reboot') return 'At system startup';
+  const fields = (Object.hasOwn(ALIASES, source) ? ALIASES[source]! : source)
+    .toUpperCase()
+    .split(/\s+/);
+  if (fields.length !== FIELDS.length) return undefined;
+
+  const normalized: string[] = [];
+  for (const [index, field] of fields.entries()) {
+    const { min, max, names } = FIELDS[index]!;
+    const value = (text: string): number => {
+      if (/^\d{1,2}$/.test(text)) return Number(text);
+      const named = names?.indexOf(text) ?? -1;
+      return named < 0 ? NaN : named + min;
+    };
+    const parts: string[] = [];
+    for (const part of field.split(',')) {
+      const match =
+        /^(\*|[A-Z]{3}|\d{1,2})(?:-([A-Z]{3}|\d{1,2}))?(?:\/(\d{1,2}))?$/.exec(
+          part
+        );
+      if (match == null) return undefined;
+      const [, start, end, stepText] = match;
+      if (start === '*' && end != null) return undefined;
+      if (stepText != null && start !== '*' && end == null) return undefined;
+      const low = start === '*' ? min : value(start!);
+      const high = start === '*' ? max : end == null ? low : value(end);
+      const step = stepText == null ? 1 : Number(stepText);
+      if (
+        !Number.isFinite(low) ||
+        !Number.isFinite(high) ||
+        low < min ||
+        high > max ||
+        low > high ||
+        step < 1 ||
+        step > max - min + 1
+      ) {
+        return undefined;
+      }
+      // A step resets at the field boundary. "Every 35 minutes" is false:
+      // */35 runs at :00 and :35, not at a constant 35-minute interval.
+      if (
+        (index === 4 && start !== '*' && high === 7 && end != null) ||
+        (stepText != null &&
+          !(start === '*' && index < 2 && (max + 1) % step === 0))
+      ) {
+        for (let n = low; n <= high; n += step) {
+          parts.push(String(index === 4 ? n % 7 : n));
+        }
+      } else {
+        parts.push(part);
+      }
+    }
+    normalized.push(parts.join(','));
+  }
+
+  try {
+    // Cron's two restricted day fields are OR, not Quartz's AND. Spell it
+    // out: cronstrue's default "and on Friday" is easy to read as AND.
+    const bothDays = !fields[2]!.includes('*') && !fields[4]!.includes('*');
+    const describe = (parts: string[]) =>
+      cronstrue.toString(parts.join(' '), {
+        use24HourTimeFormat: true,
+        throwExceptionOnParseError: true,
+        logicalAndDayFields: !bothDays,
+      });
+    if (bothDays) {
+      const byDate = [...normalized];
+      const byWeekday = [...normalized];
+      byDate[4] = '*';
+      byWeekday[2] = '*';
+      return `${describe(byDate)}; or ${describe(byWeekday)}`;
+    }
+    return describe(normalized);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Match whole literals, never a five-field substring of a different dialect.
+ * Bare entries are accepted only in cron files or an explicit schedule field. */
+export function findCronSchedules(line: string, path: string): CronSchedule[] {
+  const schedules: CronSchedule[] = [];
+  const add = (candidate: string) => {
+    const expression = candidate.trim();
+    if (schedules.some((schedule) => schedule.expression === expression))
+      return;
+    const description = describeCron(expression);
+    if (description != null) schedules.push({ expression, description });
+  };
+  // Scan literal boundaries rather than Shiki tokens: one cron string can
+  // span several tokens, and token boundaries change with the highlighter.
+  for (const match of line.matchAll(/(["'`])((?:\\.|(?!\1)[^\\\r\n])*)\1/g)) {
+    add(match[2]!);
+  }
+  const field = /(?:^|\s)(?:cron|schedule)\s*[:=]\s*([^#\r\n]*)(?:#.*)?$/i.exec(
+    line
+  );
+  if (field != null) add(field[1]!);
+  if (
+    /(?:^|\/)(?:crontab|[^/]+\.cron)$|(?:^|\/)cron\.d\//i.test(path) &&
+    !/^\s*#/.test(line)
+  ) {
+    const entry = /^\s*(@[a-z]+|\S+(?:[\t ]+\S+){4})(?=[\t ]|$)/.exec(line);
+    if (entry != null) add(entry[1]!);
+  }
+  return schedules;
+}

--- a/src/lib/cron.ts
+++ b/src/lib/cron.ts
@@ -20,6 +20,13 @@ const ALIASES: Record<string, string> = {
 // as "1W" as 1. Range validation and expansion belong to the parser, not here.
 const FIELD_PART =
   /^(?:\*(?:\/\d{1,2})?|(?:\d{1,2}|[a-z]{3})(?:-(?:\d{1,2}|[a-z]{3})(?:\/\d{1,2})?)?)$/i;
+const FIELD_SEPARATOR = /\s+/;
+const QUOTED_LITERAL = /(["'`])((?:\\.|(?!\1)[^\\\r\n])*)\1/g;
+const SCHEDULE_FIELD =
+  /(?:^|\s)(?:cron|schedule)\s*[:=]\s*([^#\r\n]*)(?:#.*)?$/i;
+const CRONTAB_PATH = /(?:^|\/)(?:crontab|[^/]+\.cron)$|(?:^|\/)cron\.d\//i;
+const CRONTAB_COMMENT = /^\s*#/;
+const CRONTAB_ENTRY = /^\s*(@[a-z]+|\S+(?:[\t ]+\S+){4})(?=[\t ]|$)/;
 
 // Turn sorted, distinct values back into concise input for the descriptor.
 // Only minutes and hours have fixed cycles: */35 is :00 and :35, whereas
@@ -60,7 +67,7 @@ export function describeCron(expression: string): string | undefined {
   if (source === '@reboot') return 'At system startup';
   const fields = (Object.hasOwn(ALIASES, source) ? ALIASES[source]! : source)
     .toUpperCase()
-    .split(/\s+/);
+    .split(FIELD_SEPARATOR);
   if (
     fields.length !== 5 ||
     fields.some((field) =>
@@ -116,18 +123,13 @@ export function findCronSchedules(line: string, path: string): CronSchedule[] {
   };
   // Scan literal boundaries rather than Shiki tokens: one cron string can
   // span several tokens, and token boundaries change with the highlighter.
-  for (const match of line.matchAll(/(["'`])((?:\\.|(?!\1)[^\\\r\n])*)\1/g)) {
+  for (const match of line.matchAll(QUOTED_LITERAL)) {
     add(match[2]!);
   }
-  const field = /(?:^|\s)(?:cron|schedule)\s*[:=]\s*([^#\r\n]*)(?:#.*)?$/i.exec(
-    line
-  );
+  const field = SCHEDULE_FIELD.exec(line);
   if (field != null) add(field[1]!);
-  if (
-    /(?:^|\/)(?:crontab|[^/]+\.cron)$|(?:^|\/)cron\.d\//i.test(path) &&
-    !/^\s*#/.test(line)
-  ) {
-    const entry = /^\s*(@[a-z]+|\S+(?:[\t ]+\S+){4})(?=[\t ]|$)/.exec(line);
+  if (CRONTAB_PATH.test(path) && !CRONTAB_COMMENT.test(line)) {
+    const entry = CRONTAB_ENTRY.exec(line);
     if (entry != null) add(entry[1]!);
   }
   return schedules;


### PR DESCRIPTION
## Summary
- Automatically describe cron expressions beside diff lines, in both split and unified views.
- Recognize complete quoted literals, explicit cron/schedule fields, and crontab entries; support standard five-field syntax and common aliases.
- Parse supported five-field cron with `cron-schedule`, normalize its sorted/deduplicated field values, and describe them with `cronstrue`. A syntax gate rejects numeric-prefix lookalikes and unsupported dialects.
- Preserve Vixie leading-wildcard day semantics and describe boundary-resetting steps such as `*/35` accurately; overlapping lists and Sunday aliases no longer produce repeated descriptions.
- Use the public item context supplied to `CodeView.onPostRender`; no protected renderer cache access.
- Render hints through the existing shadow-root post-render hook, without modifying source text, selection anchors, or virtualized line heights. Full descriptions and a scheduler-timezone caveat remain available in the native tooltip.

## Feature preview
Screenshots from the running app using a small synthetic configuration diff. Schedule descriptions appear beside the original code on both deleted and added lines; no source text is replaced.

### Split view
![Split-view cron preview: hourly and daily schedules change to every five minutes, midnight, and weekday mornings](https://raw.githubusercontent.com/myot233/ghdiff/1c3ceca74f27c6842780c79442e0103ed14d844d/.github/pr-previews/14/split.png)

### Unified view
![Unified-view cron preview showing inline descriptions for every five minutes, midnight, and Monday through Friday at 09:00](https://raw.githubusercontent.com/myot233/ghdiff/1c3ceca74f27c6842780c79442e0103ed14d844d/.github/pr-previews/14/unified.png)

The images are pinned to an immutable commit on a separate preview branch in the contributor fork; no preview assets are added to this PR's code changes.

## Verification
- `pnpm test`: 446 passing tests, including cron matching and semantic boundary coverage.
- `pnpm typecheck`, `pnpm lint`, and `pnpm fmt:check`: passed.
- `pnpm build` and `pnpm exec wrangler deploy --dry-run`: passed; Worker gzip size 3014.84 KiB, below the 3 MiB free-plan limit.
- Browser smoke checks with a fixture diff: split/unified layouts, light/dark themes, phone-width wrapped lines, clean text selection, and line-anchor navigation.

## Performance
Measured at `f16788d`. **Normal PR-like cron density adds little overhead; dense cron content on a throttled CPU has measurable frame-time regression.**

### Scrolling A/B test
- Apple M5, headless Chromium, 1365 × 768 viewport, development build, unified view.
- Synthetic diff: 100 files × 200 lines = 20,000 lines. Sparse fixture: 1% cron lines; dense fixture: every line is a cron expression.
- Each trial scrolls 57,600 px over 240 animation frames, after the diff is ready. This excludes initial download and patch parsing.
- The comparison enables/disables the cron annotation pass in memory in the same app; callback durations are instrumented. It is not a cross-branch render benchmark.
- Desktop and dense throttled cases were repeated twice per setting; sparse throttled results are one pair. CPU throttling is a stress test, not a real-phone measurement. These are development-mode measurements, not production frame-time guarantees.

| Scenario | Cron disabled: P95 frame time | Cron enabled: P95 frame time |
| --- | ---: | ---: |
| Desktop, 1% cron lines | 16.8 ms | 16.8 ms |
| Desktop, every line is cron | 16.7–16.8 ms | 16.7–16.8 ms |
| 4× CPU slowdown, 1% cron lines | 33.3 ms | 33.4 ms |
| 4× CPU slowdown, every line is cron | 25.0 ms | **33.3–33.4 ms** |

The cron annotation callback's P95 was about **0.2 ms** at sparse density and **0.4–0.5 ms** at dense density on desktop. Dense throttled runs reached **1.9–2.1 ms** per callback. Desktop enabled runs reported no long tasks; one dense throttled enabled run reported a 69 ms long task, though that entire task cannot be attributed to the cron callback alone.

### Parser and visible-row costs
- Standalone Node microbenchmarks: ordinary code / non-cron string detection approximately **0.1–0.3 μs per line**; a common cron expression plus description approximately **7.8 μs**; a complex expression approximately **15.5 μs**.
- Browser annotation microbenchmark: a cold 100-row window with cron on every row had a median of approximately **0.7 ms**; repeat passes over the same cached nodes averaged approximately **0.013 ms**.
- Work is scoped to rendered rows, not an additional full-patch scan. The current `WeakMap` cache is per DOM node, so duplicate expressions in different rows or recreated virtualized nodes are still parsed again.

### Production bundle impact
The pre-PR source (parent of the first feature commit) and the current source were built using the same installed toolchain. This comparison is separate from the development-mode scrolling test.

| Asset | Before this PR | Current | Increase |
| --- | ---: | ---: | ---: |
| Worker upload, gzip | 3006.38 KiB | 3014.84 KiB | **8.46 KiB** |
| Client review chunk, gzip | 301.46 kB | 311.18 kB | **9.72 kB** |

The Worker has **57.16 KiB** left below the free-plan 3 MiB limit. Both builds and Workers dry runs completed successfully.

### Assessment
Performance is not a blocker for ordinary reviews. The clearest potential optimization is a small bounded cache of descriptions keyed by expression, avoiding repeated parsing across rows and virtualization replacements. That optimization is **not implemented in this PR**, and its benefit would need a follow-up measurement. Worker bundle headroom also remains worth watching.

## Scope
- Descriptions use English to match the existing interface.
- No next-run calculation or browser-timezone conversion.
- Commit signed using the 1Password SSH agent.