### PR TITLE
fix(tree): keep filename ellipses stable while scrolling

### DIFF
--- a/src/components/ReviewFileTree.tsx
+++ b/src/components/ReviewFileTree.tsx
@@ -135,6 +135,9 @@ const BASE_OPTIONS = {
 const STYLE_OVERRIDES: CSSProperties = {
   '--trees-density-override': TREE_DENSITY,
   '--trees-padding-inline-override': 8,
+  // Virtualized rows remount during scroll. A fading ellipsis briefly exposes
+  // the characters it covers every time a clipped filename returns.
+  '--truncate-marker-fade-in-duration': '0s',
   // Both are the library's own defaults. They are set here because
   // treeStatLaneInset counts them, and a default that moved would take the
   // footer's totals out of the tree's columns without touching this file.


### PR DESCRIPTION
## Problem
Long filenames in a narrow file sidebar briefly show characters in place of the ellipsis while scrolling. The tree’s virtualized rows repeatedly trigger the default 100 ms ellipsis fade-in, exposing the text underneath.

## Fix
Set `--truncate-marker-fade-in-duration` to `0s` in the existing tree style overrides. Keep the library’s overflow detection, extension-preserving truncation, and layout unchanged. No dependency changes.

## Screenshots
Actual browser captures from the same public Ghostty compare, at the same 304 px sidebar width and scroll offset. The before capture pauses the active CSS transitions at a scroll frame to make the transient missing ellipsis visible; the after capture uses the fix. Notice `update-colorschemes.yml` and `GhosttyCustomConfigCase.swift`.

| Before: underlying characters exposed | After: ellipsis stays visible |
| --- | --- |
| <img src="https://raw.githubusercontent.com/myot233/ghdiff/053c18f0945a6a806be4d9fd17814146f231f40b/before.png" width="304" alt="Before: filename characters show through while the ellipsis fades in"> | <img src="https://raw.githubusercontent.com/myot233/ghdiff/053c18f0945a6a806be4d9fd17814146f231f40b/after.png" width="304" alt="After: ellipses remain opaque during scrolling"> |

Screenshots are hosted on a separate assets branch in my fork; they add no files to this PR.

## Verification
- Actual browser: scroll down and back for 120 frames on `ghostty-org/ghostty v1.3.0...v1.3.1`.
- Before: 951 of 1,280 clipped-marker observations had opacity below 1. After: 0 of 1,280.
- Narrow sidebar (220 px), light and dark: 0 of 4,947 clipped-marker observations below opacity 1 in each run.
- `pnpm exec oxlint src/components/ReviewFileTree.tsx`
- `pnpm exec oxfmt --check src/components/ReviewFileTree.tsx`